### PR TITLE
bring back meta viewport tag for responsiveness

### DIFF
--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -3,6 +3,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Larastreamers</title>
     <meta name="description" content="Larastreamers is an overview of who is streaming next in the Laravel world.">


### PR DESCRIPTION
Hi there - this meta tag was not present in the layout file - maybe by mistake? The site looked strange on the phone for that reason.