### PR TITLE
Replace deprecated dates property with casts

### DIFF
--- a/app/Models/Stream.php
+++ b/app/Models/Stream.php
@@ -11,9 +11,11 @@ class Stream extends Model
 {
     use HasFactory;
 
-    protected $dates = ['scheduled_start_time'];
-
     protected $fillable = ['channel_title', 'youtube_id', 'title', 'thumbnail_url', 'scheduled_start_time'];
+
+    protected $casts = [
+        'scheduled_start_time' => 'datetime',
+    ];
 
     public function scopeUpcoming(Builder $query): Builder
     {


### PR DESCRIPTION
The dates property is deprecated, it is recommended that the casts property is used, this PR does that.
