### PR TITLE
Add unique constraint to stream youtube id

### DIFF
--- a/database/migrations/2021_05_15_142833_unique_youtube_id_in_streams_table.php
+++ b/database/migrations/2021_05_15_142833_unique_youtube_id_in_streams_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('streams', static function (Blueprint $table) {
+            $table->unique(['youtube_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('streams', static function (Blueprint $table) {
+            $table->dropUnique(['youtube_id']);
+        });
+    }
+};


### PR DESCRIPTION
This adds a unique constraint to the `youtube_id` field in the streams table, this way streams cannot be added several times.
