### PR TITLE
Correctly close self-closing script tag

### DIFF
--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -18,7 +18,7 @@
           content="{{ asset('images/larastreamers_social.png') }}"/>
 
     <link href="{{ asset('css/app.css') }}" rel="stylesheet"/>
-    <script src="{{ asset('js/app.js') }}" />
+    <script src="{{ asset('js/app.js') }}"></script>
 
     @include('feed::links')
     @livewireStyles


### PR DESCRIPTION
<img width="993" alt="Screenshot 2021-05-15 at 17 28 35" src="https://user-images.githubusercontent.com/9739878/118369011-08fc9600-b5a3-11eb-81c0-f2817e16ae0b.png">

Apparently self-closing script tags are invalid html and can cause browsers to wrongly interpret the html.
More info here: https://stackoverflow.com/questions/69913/why-dont-self-closing-script-elements-work

In my case, my Adblocker (AdGuard) tried to block Fathom Analytics, causing the entire script tag to fail loading, resulting in Livewire not working.