### PR TITLE
add calendar route

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Stream;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Spatie\IcalendarGenerator\Components\Calendar;
+
+class CalendarController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        $calendar = Calendar::create()
+            ->name('Larastreamers')
+            ->description('There is no better way to learn than by watching other developers code live. Find out who is streaming next in the Laravel world.');
+
+        Stream::query()->each(fn(Stream $stream) => $calendar->event(
+            $stream->toCalendarItem()
+        ));
+
+        return response($calendar->get())
+            ->header('Content-Type', 'text/calendar');
+    }
+}

--- a/app/Models/Stream.php
+++ b/app/Models/Stream.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Spatie\Feed\Feedable;
 use Spatie\Feed\FeedItem;
+use Spatie\IcalendarGenerator\Components\Event;
 
 class Stream extends Model implements Feedable
 {
@@ -37,6 +38,20 @@ class Stream extends Model implements Feedable
             ->updated($this->updated_at)
             ->link($this->link())
             ->author($this->channel_title) ; //TODO: implement
+    }
+
+    public function toCalendarItem(): Event
+    {
+        return Event::create()
+            ->uniqueIdentifier($this->youtube_id)
+            ->name($this->title)
+            ->description(implode(PHP_EOL, [
+                $this->title,
+                $this->channel_title,
+                $this->link(),
+            ]))
+            ->startsAt($this->scheduled_start_time)
+            ->createdAt($this->created_at);
     }
 
     public function link(): string

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,14 @@
 {
-    "name": "laravel/laravel",
+    "name": "christophrumpel/larastreamers",
     "type": "project",
-    "description": "The Laravel Framework.",
-    "keywords": ["framework", "laravel"],
+    "description": "",
+    "keywords": [],
+    "homepage": "https://larastreamers.com",
     "license": "MIT",
     "require": {
         "php": "^8.0",
         "abraham/twitteroauth": "^2.0",
         "alaouy/youtube": "^2.2",
-        "christophrumpel/missing-livewire-assertions": "0.*",
         "fideloper/proxy": "^4.4",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
@@ -18,11 +18,13 @@
         "laravel/tinker": "^2.5",
         "livewire/livewire": "^2.0",
         "pragmarx/countries": "^0.7.2",
+        "spatie/icalendar-generator": "^2.1",
         "spatie/laravel-backup": "^7.5",
         "spatie/laravel-feed": "^3.1",
         "wildbit/swiftmailer-postmark": "^3.3"
     },
     "require-dev": {
+        "christophrumpel/missing-livewire-assertions": "0.*",
         "facade/ignition": "^2.5",
         "fakerphp/faker": "^1.9.1",
         "laravel/sail": "^1.0.1",
@@ -30,6 +32,16 @@
         "nunomaduro/collision": "^5.0",
         "phpunit/phpunit": "^9.3.3",
         "spatie/laravel-ray": "^1.17"
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "dont-discover": []
+        }
     },
     "autoload": {
         "psr-4": {
@@ -43,6 +55,8 @@
             "Tests\\": "tests/"
         }
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts": {
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
@@ -60,17 +74,5 @@
             "touch database/database.sqlite",
             "@php artisan migrate:fresh --seed --ansi"
         ]
-    },
-    "extra": {
-        "laravel": {
-            "dont-discover": []
-        }
-    },
-    "config": {
-        "optimize-autoloader": true,
-        "preferred-install": "dist",
-        "sort-packages": true
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "197ce8ff6e6a3969953e1790f5ee82e7",
+    "content-hash": "0c53d58b1c818eef025715e6db018ba5",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -292,71 +292,6 @@
                 }
             ],
             "time": "2021-01-20T22:51:39+00:00"
-        },
-        {
-            "name": "christophrumpel/missing-livewire-assertions",
-            "version": "v0.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/christophrumpel/missing-livewire-assertions.git",
-                "reference": "238a56f4e85961fb45a1d9ead0450a9f829440ab"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/christophrumpel/missing-livewire-assertions/zipball/238a56f4e85961fb45a1d9ead0450a9f829440ab",
-                "reference": "238a56f4e85961fb45a1d9ead0450a9f829440ab",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/support": "^8.0",
-                "php": "^7.4|^8.0",
-                "spatie/laravel-package-tools": "^1.4.3"
-            },
-            "require-dev": {
-                "brianium/paratest": "^6.2",
-                "livewire/livewire": "^2.4",
-                "nunomaduro/collision": "^5.3",
-                "orchestra/testbench": "^6.15",
-                "phpunit/phpunit": "^9.3",
-                "spatie/laravel-ray": "^1.9"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Christophrumpel\\MissingLivewireAssertions\\MissingLivewireAssertionsServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Christophrumpel\\MissingLivewireAssertions\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christoph Rumpel",
-                    "email": "christoph@christoph-rumpel.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "This package adds missing livewire test assertions.",
-            "homepage": "https://github.com/christophrumpel/missing-livewire-assertions",
-            "keywords": [
-                "assertions",
-                "christophrumpel",
-                "laravel",
-                "livewire"
-            ],
-            "support": {
-                "issues": "https://github.com/christophrumpel/missing-livewire-assertions/issues",
-                "source": "https://github.com/christophrumpel/missing-livewire-assertions/tree/v0.3.3"
-            },
-            "time": "2021-05-13T13:55:08+00:00"
         },
         {
             "name": "colinodell/json5",
@@ -4112,6 +4047,141 @@
             "time": "2021-04-01T07:28:47+00:00"
         },
         {
+            "name": "spatie/enum",
+            "version": "3.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/enum.git",
+                "reference": "5870275f3811dc63c08200b1536ab2f8618b6a52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/enum/zipball/5870275f3811dc63c08200b1536ab2f8618b6a52",
+                "reference": "5870275f3811dc63c08200b1536ab2f8618b6a52",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "fakerphp/faker": "^1.9.1",
+                "larapack/dd": "^1.1",
+                "phpunit/phpunit": "^9.0",
+                "vimeo/psalm": "^4.3"
+            },
+            "suggest": {
+                "fakerphp/faker": "To use the enum faker provider",
+                "phpunit/phpunit": "To use the enum assertions"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Enum\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brent Roose",
+                    "email": "brent@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Tom Witkowski",
+                    "email": "dev@gummibeer.de",
+                    "homepage": "https://gummibeer.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Enums",
+            "homepage": "https://github.com/spatie/enum",
+            "keywords": [
+                "enum",
+                "enumerable",
+                "spatie"
+            ],
+            "support": {
+                "docs": "https://docs.spatie.be/enum",
+                "issues": "https://github.com/spatie/enum/issues",
+                "source": "https://github.com/spatie/enum"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-05-10T09:27:50+00:00"
+        },
+        {
+            "name": "spatie/icalendar-generator",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/icalendar-generator.git",
+                "reference": "b57bf4d47d145574fe175cc6a13ce3bc41247b85"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/icalendar-generator/zipball/b57bf4d47d145574fe175cc6a13ce3bc41247b85",
+                "reference": "b57bf4d47d145574fe175cc6a13ce3bc41247b85",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "nesbot/carbon": "^2.41",
+                "php": "^7.4|^8.0",
+                "spatie/enum": "^3.0"
+            },
+            "require-dev": {
+                "larapack/dd": "^1.0",
+                "phpunit/phpunit": "^8.2",
+                "spatie/phpunit-snapshot-assertions": "^4.2",
+                "vimeo/psalm": "^4.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\IcalendarGenerator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ruben Van Assche",
+                    "email": "ruben@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Build calendars in the iCalendar format",
+            "homepage": "https://github.com/spatie/icalendar-generator",
+            "keywords": [
+                "calendar",
+                "iCalendar",
+                "ical",
+                "ics",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/icalendar-generator/issues",
+                "source": "https://github.com/spatie/icalendar-generator/tree/2.1.1"
+            },
+            "time": "2021-03-03T14:02:28+00:00"
+        },
+        {
             "name": "spatie/laravel-backup",
             "version": "7.5.2",
             "source": {
@@ -7041,6 +7111,71 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "christophrumpel/missing-livewire-assertions",
+            "version": "v0.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/christophrumpel/missing-livewire-assertions.git",
+                "reference": "238a56f4e85961fb45a1d9ead0450a9f829440ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/christophrumpel/missing-livewire-assertions/zipball/238a56f4e85961fb45a1d9ead0450a9f829440ab",
+                "reference": "238a56f4e85961fb45a1d9ead0450a9f829440ab",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^8.0",
+                "php": "^7.4|^8.0",
+                "spatie/laravel-package-tools": "^1.4.3"
+            },
+            "require-dev": {
+                "brianium/paratest": "^6.2",
+                "livewire/livewire": "^2.4",
+                "nunomaduro/collision": "^5.3",
+                "orchestra/testbench": "^6.15",
+                "phpunit/phpunit": "^9.3",
+                "spatie/laravel-ray": "^1.9"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Christophrumpel\\MissingLivewireAssertions\\MissingLivewireAssertionsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Christophrumpel\\MissingLivewireAssertions\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christoph Rumpel",
+                    "email": "christoph@christoph-rumpel.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "This package adds missing livewire test assertions.",
+            "homepage": "https://github.com/christophrumpel/missing-livewire-assertions",
+            "keywords": [
+                "assertions",
+                "christophrumpel",
+                "laravel",
+                "livewire"
+            ],
+            "support": {
+                "issues": "https://github.com/christophrumpel/missing-livewire-assertions/issues",
+                "source": "https://github.com/christophrumpel/missing-livewire-assertions/tree/v0.3.3"
+            },
+            "time": "2021-05-13T13:55:08+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.4.0",

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,7 +21,7 @@ Route::get('/', PageHomeController::class)
     ->name('home');
 
 Route::get('/calendar.ics', CalendarController::class)
-    ->name('home');
+    ->name('calendar.ics');
 
 Route::middleware(['auth:sanctum', 'verified'])->get('/dashboard', function () {
     return view('dashboard');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\CalendarController;
 use App\Http\Controllers\PageHomeController;
 use Illuminate\Support\Facades\Route;
 
@@ -17,6 +18,9 @@ use Illuminate\Support\Facades\Route;
 Route::feeds('feed');
 
 Route::get('/', PageHomeController::class)
+    ->name('home');
+
+Route::get('/calendar.ics', CalendarController::class)
     ->name('home');
 
 Route::middleware(['auth:sanctum', 'verified'])->get('/dashboard', function () {

--- a/tests/Feature/CalendarTest.php
+++ b/tests/Feature/CalendarTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Stream;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class CalendarTest extends TestCase
+{
+
+    use RefreshDatabase;
+
+    /** @test **/
+    public function it_shows_all_streams_in_calendar(): void
+    {
+    	// Arrange
+        $scheduledStartTime1 = Carbon::yesterday();
+        $scheduledStartTime2 = Carbon::today();
+        $scheduledStartTime3 = Carbon::now()->addDays();
+        $scheduledStartTime4 = Carbon::now()->addDays(2);
+        $scheduledStartTime5 = Carbon::now()->addDays(3);
+    	Stream::factory()->create(['title' => 'Stream #1', 'scheduled_start_time' => $scheduledStartTime1, 'youtube_id' => '1111']);
+    	Stream::factory()->create(['title' => 'Stream #2', 'scheduled_start_time' => $scheduledStartTime2, 'youtube_id' => '2222']);
+    	Stream::factory()->create(['title' => 'Stream #3', 'scheduled_start_time' => $scheduledStartTime3, 'youtube_id' => '3333']);
+    	Stream::factory()->create(['title' => 'Stream #4', 'scheduled_start_time' => $scheduledStartTime4, 'youtube_id' => '4444']);
+    	Stream::factory()->create(['title' => 'Stream #5', 'scheduled_start_time' => $scheduledStartTime5, 'youtube_id' => '5555']);
+
+    	// Act & Assert
+        $this->get('/calendar.ics')
+            ->assertHeader('Content-Type', 'text/calendar; charset=UTF-8')
+            ->assertSeeInOrder([
+                'SUMMARY:Stream #1',
+                'DESCRIPTION:Stream #1',
+                'https://www.youtube.com/watch?v=1111',
+            ])
+            ->assertSeeInOrder([
+                'SUMMARY:Stream #2',
+                'DESCRIPTION:Stream #2',
+                'https://www.youtube.com/watch?v=2222',
+            ])
+            ->assertSeeInOrder([
+                'SUMMARY:Stream #3',
+                'DESCRIPTION:Stream #3',
+                'https://www.youtube.com/watch?v=3333',
+            ])
+            ->assertSeeInOrder([
+                'SUMMARY:Stream #3',
+                'DESCRIPTION:Stream #3',
+                'https://www.youtube.com/watch?v=3333',
+            ])
+            ->assertSeeInOrder([
+                'SUMMARY:Stream #4',
+                'DESCRIPTION:Stream #4',
+                'https://www.youtube.com/watch?v=4444',
+            ])
+            ->assertSeeInOrder([
+                'SUMMARY:Stream #5',
+                'DESCRIPTION:Stream #5',
+                'https://www.youtube.com/watch?v=5555',
+            ]);
+    }
+}


### PR DESCRIPTION
This PR adds a `calendar.ics` route which returns a calendar - you can add this URL to your Calendar app to get all streams in your calendar.