### PR TITLE
Add only upcoming events to the calendar

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -15,7 +15,7 @@ class CalendarController extends Controller
             ->name('Larastreamers')
             ->description('There is no better way to learn than by watching other developers code live. Find out who is streaming next in the Laravel world.');
 
-        Stream::query()->each(fn(Stream $stream) => $calendar->event(
+        Stream::upcoming()->each(fn(Stream $stream) => $calendar->event(
             $stream->toCalendarItem()
         ));
 

--- a/app/Models/Stream.php
+++ b/app/Models/Stream.php
@@ -23,7 +23,7 @@ class Stream extends Model implements Feedable
 
     public function scopeUpcoming(Builder $query): Builder
     {
-        return $query->where('scheduled_start_time', '>', Carbon::today());
+        return $query->where('scheduled_start_time', '>=', Carbon::today());
     }
 
     public static function getFeedItems(): Collection

--- a/tests/Feature/CalendarTest.php
+++ b/tests/Feature/CalendarTest.php
@@ -29,7 +29,7 @@ class CalendarTest extends TestCase
         // Act & Assert
         $this->get('/calendar.ics')
             ->assertHeader('Content-Type', 'text/calendar; charset=UTF-8')
-            ->assertSeeInOrder([
+            ->assertDontSee([
                 'SUMMARY:Stream #1',
                 'DESCRIPTION:Stream #1',
                 'https://www.youtube.com/watch?v=1111',
@@ -38,11 +38,6 @@ class CalendarTest extends TestCase
                 'SUMMARY:Stream #2',
                 'DESCRIPTION:Stream #2',
                 'https://www.youtube.com/watch?v=2222',
-            ])
-            ->assertSeeInOrder([
-                'SUMMARY:Stream #3',
-                'DESCRIPTION:Stream #3',
-                'https://www.youtube.com/watch?v=3333',
             ])
             ->assertSeeInOrder([
                 'SUMMARY:Stream #3',


### PR DESCRIPTION
Currently the CalendarController adds all streams to the calendar. This isn't a huge problem yet but in the future there will be a huge amount of streams added to the calendar for no real reason.

I also updated the `upcoming` scope to return all streams starting at the exact start of the day (2020-05-17 00:00:00) instead of 2020-05-17 00:00:01.