### PR TITLE
Fix image aspect ratio on safari

### DIFF
--- a/resources/views/pages/partials/stream.blade.php
+++ b/resources/views/pages/partials/stream.blade.php
@@ -1,8 +1,10 @@
 <div class="bg-blue-100 rounded-md overflow-hidden">
     <a class="block flex flex-col md:flex-row" target="_blank"
        href="{{ $stream->link() }}">
-        <img class="w-full md:w-96 md:border-r-8 md:border-gray-800" src="{{ $stream->thumbnail_url }}" width="400"
-             alt="Youtube Live Stream Preview image"/>
+        <div>
+            <img class="w-full md:w-96 md:border-r-8 md:border-gray-800" src="{{ $stream->thumbnail_url }}" width="400"
+                 alt="Youtube Live Stream Preview image"/>
+        </div>
         <div class="md:border-l-8 md:border-gray-800 px-8 py-8 md:py-4">
             @ray($stream->scheduled_start_time)
             <x-local-time class="block text-2xl mb-2 text-gray-600" :date="$stream->scheduled_start_time" />


### PR DESCRIPTION
The YouTube thumbnail preview images are broken on safari due to some flex issues. As a "quick fix" I just wrapped the image inside a div, maybe there is a better solution.

Before
<img width="360" alt="CleanShot 2021-05-17 at 14 28 47@2x" src="https://user-images.githubusercontent.com/24483576/118488837-708a2100-b71c-11eb-8273-69e0b521d641.png">

After
<img width="641" alt="CleanShot 2021-05-17 at 14 28 27@2x" src="https://user-images.githubusercontent.com/24483576/118488872-797af280-b71c-11eb-89f0-b603013a0c9e.png">
