### PR TITLE
Never ever hit the real api during tests

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,14 +12,23 @@ abstract class TestCase extends BaseTestCase
 
     protected TwitterFake $twitterFake;
 
+    private string $originalYoutubeApiKey;
+
     public function setUp(): void
     {
         parent::setUp();
 
+        $this->originalYoutubeApiKey = config('services.youtube.key');
+        config()->set('services.youtube.key', 'FAKE-KEY');
         $this->twitterFake = new TwitterFake();
         $this->app->instance(Twitter::class, $this->twitterFake);
 
         ray()->newScreen($this->getName());
+    }
+
+    protected function useRealYoutubeApi(): void
+    {
+        config()->set('services.youtube.key', $this->originalYoutubeApiKey);
     }
 
     protected function channelResponse(): array

--- a/tests/Unit/YoutubeTest.php
+++ b/tests/Unit/YoutubeTest.php
@@ -63,4 +63,16 @@ class YoutubeTest extends TestCase
         $this->assertEquals('2021-05-21T09:00:00+00:00', $upcomingStream->plannedStart->toIso8601String());
         $this->assertEquals(StreamData::STATUS_UPCOMING, $upcomingStream->status);
     }
+
+    /** @test */
+    public function it_uses_real_api_key_when_needed(): void
+    {
+        $this->assertEquals('FAKE-KEY', config()->get('services.youtube.key'));
+
+        $this->useRealYoutubeApi();
+
+        config()->set('services.youtube.key', 'REAL-API-KEY');
+        $this->assertEquals('REAL-API-KEY', config()->get('services.youtube.key'));
+
+    }
 }


### PR DESCRIPTION
The default behavior in all tests:
YouTube API Key will be overwritten with a fake one.

If there is a need to run a test against the real API simply call:
`$this->useRealYoutubeApi()` in your test