### PR TITLE
Add webcal links for streams

### DIFF
--- a/app/Models/Stream.php
+++ b/app/Models/Stream.php
@@ -104,4 +104,11 @@ class Stream extends Model implements Feedable
     {
         return "https://www.youtube.com/watch?v={$this->youtube_id}";
     }
+
+    public function toWebcalLink(): string
+    {
+        $url = parse_url(route('calendar.ics.stream', $this));
+
+        return "webcal://{$url['host']}{$url['path']}";
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -23,6 +24,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        View::composer('*', function ($view) {
+            $url = parse_url(route('calendar.ics'));
+            $webcalLink = "webcal://{$url['host']}{$url['path']}";
+            $view->with('webcalLink', $webcalLink);
+        });
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -24,10 +23,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        View::composer('*', function ($view) {
-            $url = parse_url(route('calendar.ics'));
-            $webcalLink = "webcal://{$url['host']}{$url['path']}";
-            $view->with('webcalLink', $webcalLink);
-        });
+        //
     }
 }

--- a/app/View/Components/AddStreamsToCalendar.php
+++ b/app/View/Components/AddStreamsToCalendar.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\View\Components;
+
+use Illuminate\View\Component;
+
+class AddStreamsToCalendar extends Component
+{
+    public string $webcalLink;
+
+    public function __construct()
+    {
+        $url = parse_url(route('calendar.ics'));
+        $webcalLink = "webcal://{$url['host']}{$url['path']}";
+
+        $this->webcalLink = $webcalLink;
+    }
+
+    public function render()
+    {
+        return view('components.add-streams-to-calendar');
+    }
+}

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1107,6 +1107,17 @@ select {
 .aspect-h-9 {
 	--tw-aspect-h: 9;
 }
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border-width: 0;
+}
 .pointer-events-none {
 	pointer-events: none;
 }
@@ -1138,9 +1149,6 @@ select {
 .right-0 {
 	right: 0px;
 }
-.top-0 {
-	top: 0px;
-}
 .top-2\.5 {
 	top: 0.625rem;
 }
@@ -1153,17 +1161,20 @@ select {
 .right-2 {
 	right: 0.5rem;
 }
+.top-0 {
+	top: 0px;
+}
 .z-0 {
 	z-index: 0;
 }
 .z-50 {
 	z-index: 50;
 }
-.z-20 {
-	z-index: 20;
-}
 .z-10 {
 	z-index: 10;
+}
+.z-20 {
+	z-index: 20;
 }
 .col-span-6 {
 	grid-column: span 6 / span 6;
@@ -1248,11 +1259,11 @@ select {
 .mt-12 {
 	margin-top: 3rem;
 }
-.mt-1\.5 {
-	margin-top: 0.375rem;
-}
 .-mt-px {
 	margin-top: -1px;
+}
+.mt-1\.5 {
+	margin-top: 0.375rem;
 }
 .block {
 	display: block;
@@ -1265,9 +1276,6 @@ select {
 }
 .inline-flex {
 	display: inline-flex;
-}
-.table {
-	display: table;
 }
 .grid {
 	display: grid;
@@ -1358,6 +1366,9 @@ select {
 }
 .w-2 {
 	width: 0.5rem;
+}
+.w-56 {
+	width: 14rem;
 }
 .min-w-0 {
 	min-width: 0px;
@@ -1508,20 +1519,25 @@ select {
 	margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
 	margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
 }
-.space-y-16 > :not([hidden]) ~ :not([hidden]) {
-	--tw-space-y-reverse: 0;
-	margin-top: calc(4rem * calc(1 - var(--tw-space-y-reverse)));
-	margin-bottom: calc(4rem * var(--tw-space-y-reverse));
+.space-x-2 > :not([hidden]) ~ :not([hidden]) {
+	--tw-space-x-reverse: 0;
+	margin-right: calc(0.5rem * var(--tw-space-x-reverse));
+	margin-left: calc(0.5rem * calc(1 - var(--tw-space-x-reverse)));
 }
 .space-y-2 > :not([hidden]) ~ :not([hidden]) {
 	--tw-space-y-reverse: 0;
 	margin-top: calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));
 	margin-bottom: calc(0.5rem * var(--tw-space-y-reverse));
 }
-.space-x-2 > :not([hidden]) ~ :not([hidden]) {
+.space-x-4 > :not([hidden]) ~ :not([hidden]) {
 	--tw-space-x-reverse: 0;
-	margin-right: calc(0.5rem * var(--tw-space-x-reverse));
-	margin-left: calc(0.5rem * calc(1 - var(--tw-space-x-reverse)));
+	margin-right: calc(1rem * var(--tw-space-x-reverse));
+	margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
+}
+.space-y-16 > :not([hidden]) ~ :not([hidden]) {
+	--tw-space-y-reverse: 0;
+	margin-top: calc(4rem * calc(1 - var(--tw-space-y-reverse)));
+	margin-bottom: calc(4rem * var(--tw-space-y-reverse));
 }
 .space-y-4 > :not([hidden]) ~ :not([hidden]) {
 	--tw-space-y-reverse: 0;
@@ -1549,9 +1565,6 @@ select {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-}
-.break-all {
-	word-break: break-all;
 }
 .rounded-md {
 	border-radius: 0.375rem;
@@ -1588,6 +1601,10 @@ select {
 .rounded-b-xl {
 	border-bottom-right-radius: 0.75rem;
 	border-bottom-left-radius: 0.75rem;
+}
+.rounded-r-none {
+	border-top-right-radius: 0px;
+	border-bottom-right-radius: 0px;
 }
 .border {
 	border-width: 1px;
@@ -1632,13 +1649,13 @@ select {
 	--tw-border-opacity: 1;
 	border-color: rgba(243, 244, 246, var(--tw-border-opacity));
 }
-.border-gray-600 {
-	--tw-border-opacity: 1;
-	border-color: rgba(75, 85, 99, var(--tw-border-opacity));
-}
 .border-gray-400 {
 	--tw-border-opacity: 1;
 	border-color: rgba(156, 163, 175, var(--tw-border-opacity));
+}
+.border-gray-600 {
+	--tw-border-opacity: 1;
+	border-color: rgba(75, 85, 99, var(--tw-border-opacity));
 }
 .bg-white {
 	--tw-bg-opacity: 1;
@@ -1688,14 +1705,6 @@ select {
 	--tw-bg-opacity: 1;
 	background-color: rgba(229, 231, 235, var(--tw-bg-opacity));
 }
-.bg-gray-700 {
-	--tw-bg-opacity: 1;
-	background-color: rgba(55, 65, 81, var(--tw-bg-opacity));
-}
-.bg-green-200 {
-	--tw-bg-opacity: 1;
-	background-color: rgba(167, 243, 208, var(--tw-bg-opacity));
-}
 .bg-gray-900 {
 	--tw-bg-opacity: 1;
 	background-color: rgba(17, 24, 39, var(--tw-bg-opacity));
@@ -1708,14 +1717,22 @@ select {
 	--tw-bg-opacity: 1;
 	background-color: rgba(75, 85, 99, var(--tw-bg-opacity));
 }
+.bg-green-200 {
+	--tw-bg-opacity: 1;
+	background-color: rgba(167, 243, 208, var(--tw-bg-opacity));
+}
+.bg-gray-700 {
+	--tw-bg-opacity: 1;
+	background-color: rgba(55, 65, 81, var(--tw-bg-opacity));
+}
 .bg-opacity-25 {
 	--tw-bg-opacity: 0.25;
 }
-.bg-opacity-90 {
-	--tw-bg-opacity: 0.9;
-}
 .bg-opacity-80 {
 	--tw-bg-opacity: 0.8;
+}
+.bg-opacity-90 {
+	--tw-bg-opacity: 0.9;
 }
 .bg-none {
 	background-image: none;
@@ -1820,11 +1837,11 @@ select {
 .pb-1 {
 	padding-bottom: 0.25rem;
 }
-.pr-10 {
-	padding-right: 2.5rem;
-}
 .pt-8 {
 	padding-top: 2rem;
+}
+.pr-10 {
+	padding-right: 2.5rem;
 }
 .text-center {
 	text-align: center;
@@ -1900,11 +1917,11 @@ select {
 .tracking-widest {
 	letter-spacing: 0.1em;
 }
-.tracking-tight {
-	letter-spacing: -0.025em;
-}
 .tracking-wider {
 	letter-spacing: 0.05em;
+}
+.tracking-tight {
+	letter-spacing: -0.025em;
 }
 .text-gray-500 {
 	--tw-text-opacity: 1;
@@ -1966,21 +1983,21 @@ select {
 	--tw-text-opacity: 1;
 	color: rgba(16, 185, 129, var(--tw-text-opacity));
 }
-.text-red-400 {
-	--tw-text-opacity: 1;
-	color: rgba(248, 113, 113, var(--tw-text-opacity));
-}
-.text-green-800 {
-	--tw-text-opacity: 1;
-	color: rgba(6, 95, 70, var(--tw-text-opacity));
-}
 .text-gray-100 {
 	--tw-text-opacity: 1;
 	color: rgba(243, 244, 246, var(--tw-text-opacity));
 }
+.text-red-400 {
+	--tw-text-opacity: 1;
+	color: rgba(248, 113, 113, var(--tw-text-opacity));
+}
 .text-gray-300 {
 	--tw-text-opacity: 1;
 	color: rgba(209, 213, 219, var(--tw-text-opacity));
+}
+.text-green-800 {
+	--tw-text-opacity: 1;
+	color: rgba(6, 95, 70, var(--tw-text-opacity));
 }
 .text-gray-200 {
 	--tw-text-opacity: 1;
@@ -2066,11 +2083,11 @@ select {
 	-webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
 	        backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
 }
-.backdrop-blur-lg {
-	--tw-backdrop-blur: blur(16px);
-}
 .backdrop-blur-xl {
 	--tw-backdrop-blur: blur(24px);
+}
+.backdrop-blur-lg {
+	--tw-backdrop-blur: blur(16px);
 }
 .backdrop-saturate-150 {
 	--tw-backdrop-saturate: saturate(1.5);
@@ -2102,6 +2119,9 @@ select {
 .duration-300 {
 	transition-duration: 300ms;
 }
+.duration-100 {
+	transition-duration: 100ms;
+}
 .ease-in-out {
 	transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -2110,6 +2130,9 @@ select {
 }
 .ease-in {
 	transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+}
+[x-cloak] {
+    display: none;
 }
 .hover\:border-gray-300:hover {
 	--tw-border-opacity: 1;
@@ -2250,14 +2273,19 @@ select {
 	--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
 	box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }
+.focus\:ring-4:focus {
+	--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+	--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+	box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
 .focus\:ring-2:focus {
 	--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
 	--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
 	box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }
-.focus\:ring-4:focus {
+.focus\:ring-1:focus {
 	--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-	--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+	--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
 	box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }
 .focus\:ring-gray-300:focus {
@@ -2276,13 +2304,13 @@ select {
 	--tw-ring-opacity: 1;
 	--tw-ring-color: rgba(191, 219, 254, var(--tw-ring-opacity));
 }
-.focus\:ring-indigo-500:focus {
-	--tw-ring-opacity: 1;
-	--tw-ring-color: rgba(99, 102, 241, var(--tw-ring-opacity));
-}
 .focus\:ring-red-400:focus {
 	--tw-ring-opacity: 1;
 	--tw-ring-color: rgba(248, 113, 113, var(--tw-ring-opacity));
+}
+.focus\:ring-indigo-500:focus {
+	--tw-ring-opacity: 1;
+	--tw-ring-color: rgba(99, 102, 241, var(--tw-ring-opacity));
 }
 .focus\:ring-opacity-50:focus {
 	--tw-ring-opacity: 0.5;
@@ -2370,10 +2398,6 @@ select {
 		margin-left: 1.5rem;
 	}
 
-	.sm\:ml-0 {
-		margin-left: 0px;
-	}
-
 	.sm\:block {
 		display: block;
 	}
@@ -2388,10 +2412,6 @@ select {
 
 	.sm\:h-10 {
 		height: 2.5rem;
-	}
-
-	.sm\:h-20 {
-		height: 5rem;
 	}
 
 	.sm\:w-10 {
@@ -2515,10 +2535,6 @@ select {
 		text-align: left;
 	}
 
-	.sm\:text-right {
-		text-align: right;
-	}
-
 	.sm\:text-sm {
 		font-size: 0.875rem;
 		line-height: 1.25rem;
@@ -2605,12 +2621,12 @@ select {
 		grid-column: span 4 / span 4;
 	}
 
-	.lg\:grid-cols-1 {
-		grid-template-columns: repeat(1, minmax(0, 1fr));
-	}
-
 	.lg\:grid-cols-\[1fr\2c 2fr\] {
 		grid-template-columns: 1fr 2fr;
+	}
+
+	.lg\:grid-cols-1 {
+		grid-template-columns: repeat(1, minmax(0, 1fr));
 	}
 
 	.lg\:gap-4 {
@@ -2626,4 +2642,3 @@ select {
 		padding-right: 2rem;
 	}
 }
-

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
     "/js/app.js": "/js/app.js?id=320e903d90a54ebdbc64",
-    "/css/app.css": "/css/app.css?id=697237c37b7a4d11970f"
+    "/css/app.css": "/css/app.css?id=60aa1d2e40e587c5b4db"
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,7 @@
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
+
+[x-cloak] {
+    display: none;
+}

--- a/resources/views/components/add-streams-to-calendar.blade.php
+++ b/resources/views/components/add-streams-to-calendar.blade.php
@@ -1,0 +1,40 @@
+<div class="relative z-0 inline-flex shadow-sm rounded-md" x-data="{ show: false }">
+    <a
+            href="{{ $webcalLink }}"
+            class="relative flex items-center px-3 py-2 text-sm font-medium text-white transition bg-red-600 rounded-md rounded-r-none shadow hover:bg-red-500 focus:bg-red-700 focus:outline-none focus:ring focus:ring-red-400"
+    >
+        Add streams to calendar
+    </a>
+
+    <div class="-ml-px relative block">
+        <button type="button"
+                class="relative inline-flex items-center px-2 py-2 rounded-r-md bg-red-600 hover:bg-red-500 text-sm font-medium focus:z-10 focus:outline-none focus:ring focus:ring-red-400"
+                @click="show = !show"
+        >
+            <span class="sr-only">Open dropdown</span>
+
+            <x-icons.chevron-down />
+        </button>
+
+        <div
+                class="origin-top-right absolute right-0 mt-2 -mr-1 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none focus:ring focus:ring-red-400"
+                x-cloak
+                x-show="show"
+                @click.away="show = false"
+                x-transition:enter="transition ease-out duration-100"
+                x-transition:enter-start="transform opacity-0 scale-95"
+                x-transition:enter-end="transform opacity-100 scale-100"
+                x-transition:leave="transition ease-in duration-75"
+                x-transition:leave-start="transform opacity-100 scale-100"
+                x-transition:leave-end="transform opacity-0 scale-95"
+        >
+            <div class="py-1">
+                <a href="{{ route('calendar.ics') }}"
+                   class="text-gray-700 block px-4 py-2 text-sm"
+                >
+                    Download .ics file
+                </a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/components/icons/calendar.blade.php
+++ b/resources/views/components/icons/calendar.blade.php
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     class="w-6 h-6 text-gray-300"
+     fill="none"
+     viewBox="0 0 24 24"
+     stroke="currentColor"
+>
+    <path stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1"
+          d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+    />
+</svg>

--- a/resources/views/components/icons/chevron-down.blade.php
+++ b/resources/views/components/icons/chevron-down.blade.php
@@ -1,0 +1,12 @@
+<svg
+        class="h-5 w-5 text-white"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+>
+    <path fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+    />
+</svg>

--- a/resources/views/components/icons/download.blade.php
+++ b/resources/views/components/icons/download.blade.php
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     class="w-6 h-6 text-gray-300"
+     fill="none"
+     viewBox="0 0 24 24"
+     stroke="currentColor"
+>
+    <path stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+    />
+</svg>

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -68,10 +68,7 @@
                     </p>
                 </aside>
 
-                <a class="px-3 py-2 text-sm font-medium text-white transition bg-red-600 rounded-md shadow hover:bg-red-500 focus:bg-red-700 focus:outline-none"
-                    href="{{ route('calendar.ics') }}">
-                    Add streams to calendar
-                </a>
+                <x-add-streams-to-calendar />
             </header>
         </div>
     </section>

--- a/resources/views/pages/partials/stream.blade.php
+++ b/resources/views/pages/partials/stream.blade.php
@@ -43,20 +43,20 @@
 
         <ul class="flex flex-wrap gap-6">
             <li>
-                <a href="{{ route('calendar.ics.stream', $stream) }}"
-                    class="inline-flex items-center space-x-2 transition hover:text-gray-300">
-                    <svg xmlns="http://www.w3.org/2000/svg"
-                        class="w-6 h-6 text-gray-300"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor">
-                        <path stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="1"
-                            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                    </svg>
+                <a href="{{ $stream->toWebcalLink() }}"
+                   class="inline-flex items-center space-x-2 transition hover:text-gray-300">
+                    <x-icons.calendar />
 
                     <span class="text-sm font-medium">Add to calendar</span>
+                </a>
+            </li>
+
+            <li>
+                <a href="{{ route('calendar.ics.stream', $stream) }}"
+                   class="inline-flex items-center space-x-2 transition hover:text-gray-300">
+                    <x-icons.download />
+
+                    <span class="text-sm font-medium">Download .ics file</span>
                 </a>
             </li>
         </ul>


### PR DESCRIPTION
This PR adds the possibility to subscribe to the calendar or specific events using `webcal`.

Depending on the device and operating system the calendar will automatically be added to the default calendar application (Mac, iPhone) or the browser will ask for the calendar application (Windows).

As fallback (if webcal is not supported) the .ics files can still be downloaded as currently implemented.

I did a bit of frontend work which looks like this
<img width="775" alt="CleanShot 2021-05-20 at 14 06 42@2x" src="https://user-images.githubusercontent.com/24483576/118975784-a1649300-b974-11eb-8a31-c3dca2d54ee6.png">

<img width="300" alt="CleanShot 2021-05-20 at 14 07 00@2x" src="https://user-images.githubusercontent.com/24483576/118975830-aa556480-b974-11eb-831b-ed1553ef339f.png">

I marked this one as a draft since there is probably some refactoring required.
