### PR TITLE
Add the missing space between "Add to calender" & "Download .ics file"

### DIFF
--- a/resources/views/pages/partials/stream.blade.php
+++ b/resources/views/pages/partials/stream.blade.php
@@ -47,7 +47,7 @@
                    class="inline-flex items-center space-x-2 transition hover:text-gray-300">
                     <x-icons.calendar />
 
-                    <span class="text-sm font-medium">Add to calendar</span>
+                    <span class="text-sm font-medium pr-10">Add to calendar</span>
                 </a>
             </li>
 


### PR DESCRIPTION
Add the missing space between "Add to calender" & "Download .ics file".

**Before**
![before](https://user-images.githubusercontent.com/50302555/119133009-36db5200-ba5d-11eb-8871-a2cdb46cf6b1.png)

**After**
![after](https://user-images.githubusercontent.com/50302555/119133028-3d69c980-ba5d-11eb-96fb-559d5e3535aa.png)
