### PR TITLE
Add Pagination

### DIFF
--- a/app/Actions/PrepareStreams.php
+++ b/app/Actions/PrepareStreams.php
@@ -8,12 +8,9 @@ use Illuminate\Support\Collection;
 
 class PrepareStreams
 {
-    private bool $isDescending = false;
-
     public function handle(Collection $streams): Collection
     {
         return $streams
-            ->sortBy('scheduled_start_time', null, $this->isDescending)
             ->groupBy(static fn(Stream $item): string => $item->scheduled_start_time->format('D d.m.Y'))
             ->mapWithKeys(static function(Collection $item, string $date): array {
                 $dateObject = Carbon::createFromFormat('D d.m.Y', $date);
@@ -32,12 +29,5 @@ class PrepareStreams
 
                 return [$date => $item];
             });
-    }
-
-    public function fromLatestToOldest(): static
-    {
-        $this->isDescending = true;
-
-        return $this;
     }
 }

--- a/app/Actions/SortStreamsByDateAction.php
+++ b/app/Actions/SortStreamsByDateAction.php
@@ -6,7 +6,7 @@ use App\Models\Stream;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
-class PrepareStreams
+class SortStreamsByDateAction
 {
     public function handle(Collection $streams): Collection
     {

--- a/app/Http/Controllers/ArchiveController.php
+++ b/app/Http/Controllers/ArchiveController.php
@@ -2,18 +2,12 @@
 
 namespace App\Http\Controllers;
 
-use App\Actions\PrepareStreams;
-use App\Models\Stream;
 use Illuminate\Contracts\View\View;
 
 class ArchiveController extends Controller
 {
     public function __invoke(): View
     {
-        $pastStreams = (new PrepareStreams())
-            ->fromLatestToOldest()
-            ->handle(Stream::query()->approved()->finished()->latest()->get());
-
-        return view('pages.archive', ['pastStreamsByDate' => $pastStreams]);
+        return view('pages.archive');
     }
 }

--- a/app/Http/Controllers/PageHomeController.php
+++ b/app/Http/Controllers/PageHomeController.php
@@ -2,16 +2,12 @@
 
 namespace App\Http\Controllers;
 
-use App\Actions\PrepareStreams;
-use App\Models\Stream;
 use Illuminate\Contracts\View\View;
 
 class PageHomeController extends Controller
 {
-    public function __invoke(PrepareStreams $prepareStreams): View
+    public function __invoke(): View
     {
-        return view('pages.home', [
-            'streamsByDate' => $prepareStreams->handle(Stream::approved()->upcoming()->get()),
-        ]);
+        return view('pages.home');
     }
 }

--- a/app/Http/Livewire/StreamList.php
+++ b/app/Http/Livewire/StreamList.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Livewire;
 
-use App\Actions\PrepareStreams;
+use App\Actions\SortStreamsByDateAction;
 use App\Models\Stream;
 use Illuminate\Contracts\View\View;
 use Livewire\Component;
@@ -26,7 +26,7 @@ class StreamList extends Component
 
         return view('livewire.stream-list', [
             'streamsByDate' => $streams->setCollection(
-                (new PrepareStreams())->handle($streams->getCollection())
+                (new SortStreamsByDateAction())->handle($streams->getCollection())
             ),
         ]);
     }

--- a/database/seeders/TestDataSeeder.php
+++ b/database/seeders/TestDataSeeder.php
@@ -26,12 +26,12 @@ class TestDataSeeder extends Seeder
         Stream::truncate();
 
         Stream::factory()
-            ->count(10)
+            ->count(100)
             ->create();
 
         Stream::factory()
             ->finished()
-            ->count(10)
+            ->count(100)
             ->create();
     }
 }

--- a/resources/views/livewire/stream-list.blade.php
+++ b/resources/views/livewire/stream-list.blade.php
@@ -19,4 +19,8 @@
             </div>
         </section>
     @endforeach
+
+    <div class="w-full max-w-6xl px-4 mx-auto sm:px-6 md:px-8">
+        {{ $streamsByDate->links() }}
+    </div>
 </div>

--- a/resources/views/pages/archive.blade.php
+++ b/resources/views/pages/archive.blade.php
@@ -1,5 +1,5 @@
 <x-main-layout :show-calendar-downloads="false" title="Larastreamers Archive" description="Did you miss a stream? Don't worry. Just scroll through the archive and watch it now.">
     <h2 class="mt-12 text-4xl text-center">Archive</h2>
-    <livewire:stream-list :streams-by-date="$pastStreamsByDate" :is-archive="true" />
+    <livewire:stream-list :is-archive="true" />
 </x-main-layout>
 

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -1,3 +1,3 @@
 <x-main-layout>
-    <livewire:stream-list :streams-by-date="$streamsByDate"/>
+    <livewire:stream-list />
 </x-main-layout>

--- a/tests/Feature/PrepareStreamsTest.php
+++ b/tests/Feature/PrepareStreamsTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature;
 
-use App\Actions\PrepareStreams;
+use App\Actions\SortStreamsByDateAction;
 use App\Models\Stream;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -24,7 +24,7 @@ class PrepareStreamsTest extends TestCase
                 ['scheduled_start_time' => Carbon::tomorrow()->addDay()],
             ))->create();
 
-        $prepareStreamsAction = new PrepareStreams;
+        $prepareStreamsAction = new SortStreamsByDateAction;
 
         // Act
         $preparedStreams = $prepareStreamsAction->handle($streams);
@@ -48,7 +48,7 @@ class PrepareStreamsTest extends TestCase
                 ['scheduled_start_time' => Carbon::tomorrow()->addDay()],
             ))->create();
 
-        $prepareStreamsAction = new PrepareStreams;
+        $prepareStreamsAction = new SortStreamsByDateAction;
 
         // Act
         $preparedStreams = $prepareStreamsAction->handle($streams);
@@ -64,7 +64,7 @@ class PrepareStreamsTest extends TestCase
     public function it_orders_past_streams_from_latest_to_oldest(): void
     {
         $this->markTestSkipped('Sorting is not longer done in the PrepareSteams..');
-        
+
         $this->travelTo(Carbon::parse('2021-06-11 00:00'));
 
         // Arrange
@@ -75,7 +75,7 @@ class PrepareStreamsTest extends TestCase
                 ['scheduled_start_time' => Carbon::yesterday()->subDays(2)],
             ))->create();
 
-        $prepareStreamsAction = new PrepareStreams;
+        $prepareStreamsAction = new SortStreamsByDateAction;
 
         // Act
         $preparedStreams = $prepareStreamsAction

--- a/tests/Feature/PrepareStreamsTest.php
+++ b/tests/Feature/PrepareStreamsTest.php
@@ -63,6 +63,8 @@ class PrepareStreamsTest extends TestCase
     /** @test */
     public function it_orders_past_streams_from_latest_to_oldest(): void
     {
+        $this->markTestSkipped('Sorting is not longer done in the PrepareSteams..');
+        
         $this->travelTo(Carbon::parse('2021-06-11 00:00'));
 
         // Arrange

--- a/tests/Feature/PrepareStreamsTest.php
+++ b/tests/Feature/PrepareStreamsTest.php
@@ -59,33 +59,4 @@ class PrepareStreamsTest extends TestCase
             'Sun 13.06.2021',
         ], $preparedStreams->keys()->toArray());
     }
-
-    /** @test */
-    public function it_orders_past_streams_from_latest_to_oldest(): void
-    {
-        $this->markTestSkipped('Sorting is not longer done in the PrepareSteams..');
-
-        $this->travelTo(Carbon::parse('2021-06-11 00:00'));
-
-        // Arrange
-        $streams = Stream::factory()->count(3)
-            ->state(new Sequence(
-                ['scheduled_start_time' => Carbon::yesterday()],
-                ['scheduled_start_time' => Carbon::yesterday()->subDay()],
-                ['scheduled_start_time' => Carbon::yesterday()->subDays(2)],
-            ))->create();
-
-        $prepareStreamsAction = new SortStreamsByDateAction;
-
-        // Act
-        $preparedStreams = $prepareStreamsAction
-            ->fromLatestToOldest()
-            ->handle($streams);
-
-        $this->assertEquals([
-            'Yesterday',
-            'Wed 09.06.2021',
-            'Tue 08.06.2021',
-        ], $preparedStreams->keys()->toArray());
-    }
 }


### PR DESCRIPTION
Hi Christoph, 

I saw on the stream that you wanted to add pagination so i took a crack at it with this pull requests. 

I though the best way to do it is by retrieving the Steams in the livewire component instead of the Controllers. (Because that way livewire can paginate). 

Take a look at the changes if you like. Don't know if i did it the way you would like to structure things. 

Some things to consider: 
- Styling on the pagination links needs some work. 
- When clicking a pagination link it's doesn't scroll back to the top. 
- Maybe use a different qty per page.
- I marked one test as skipped because i removed the method from PrepareStreams (it was no longer used). So maybe another test needs to be written in place?