### PR TITLE
Fix bug with not adding twitter handle for channels

### DIFF
--- a/app/Jobs/ImportYoutubeChannelStreamsJob.php
+++ b/app/Jobs/ImportYoutubeChannelStreamsJob.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\Facades\Youtube;
+use App\Models\Channel;
 use App\Models\Stream;
 use App\Services\Youtube\StreamData;
 use Illuminate\Bus\Queueable;
@@ -25,7 +26,7 @@ class ImportYoutubeChannelStreamsJob implements ShouldQueue
 
         $streams->map(function(StreamData $streamData) {
             Stream::updateOrCreate(['youtube_id' => $streamData->videoId], [
-                'channel_id' => $streamData->channelId,
+                'channel_id' => optional(Channel::where('platform_id', $streamData->channelId)->first())->id,
                 'youtube_id' => $streamData->videoId,
                 'title' => $streamData->title,
                 'description' => $streamData->description,

--- a/tests/Feature/Commands/TweetAboutLiveStreamsCommandTest.php
+++ b/tests/Feature/Commands/TweetAboutLiveStreamsCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Commands;
 
 use App\Console\Commands\TweetAboutLiveStreamsCommand;
 use App\Models\Channel;
@@ -10,7 +10,7 @@ use Artisan;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class TweetTest extends TestCase
+class TweetAboutLiveStreamsCommandTest extends TestCase
 {
     use RefreshDatabase;
 

--- a/tests/Feature/Commands/TweetAboutLiveStreamsCommandTest.php
+++ b/tests/Feature/Commands/TweetAboutLiveStreamsCommandTest.php
@@ -6,7 +6,6 @@ use App\Console\Commands\TweetAboutLiveStreamsCommand;
 use App\Models\Channel;
 use App\Models\Stream;
 use App\Services\Youtube\StreamData;
-use Artisan;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -18,13 +17,13 @@ class TweetAboutLiveStreamsCommandTest extends TestCase
     public function it_only_tweets_streams_that_are_live(): void
     {
         // Arrange
-        Stream::factory()->create(['status' => StreamData::STATUS_LIVE]);
+        Stream::factory()->live()->create();
 
         // Assert
         $this->twitterFake->assertNoTweetsWereSent();
 
         // Act
-        Artisan::call(TweetAboutLiveStreamsCommand::class);
+        $this->artisan(TweetAboutLiveStreamsCommand::class);
 
         // Assert
         $this->twitterFake->assertTweetWasSent();
@@ -34,11 +33,11 @@ class TweetAboutLiveStreamsCommandTest extends TestCase
     public function it_checks_the_message_of_the_tweet(): void
     {
         // Arrange
-        $stream = Stream::factory()->create(['status' => StreamData::STATUS_LIVE]);
+        $stream = Stream::factory()->live()->create();
         $expectedStatus = "🔴 A new stream just started: $stream->title\nhttps://www.youtube.com/watch?v=$stream->youtube_id";
 
         // Act
-        Artisan::call(TweetAboutLiveStreamsCommand::class);
+        $this->artisan(TweetAboutLiveStreamsCommand::class);
 
         // Assert
         $this->twitterFake->assertLastTweetMessageWas($expectedStatus);
@@ -55,7 +54,7 @@ class TweetAboutLiveStreamsCommandTest extends TestCase
         $expectedStatus = "🔴 A new stream by @twitterUser just started: $stream->title\nhttps://www.youtube.com/watch?v=$stream->youtube_id";
 
         // Act
-        Artisan::call(TweetAboutLiveStreamsCommand::class);
+        $this->artisan(TweetAboutLiveStreamsCommand::class);
 
         // Assert
         $this->twitterFake->assertLastTweetMessageWas($expectedStatus);
@@ -66,13 +65,14 @@ class TweetAboutLiveStreamsCommandTest extends TestCase
     {
         // Arrange
         $stream = Stream::factory()
+            ->live()
             ->for(Channel::factory())
-            ->create(['status' => StreamData::STATUS_LIVE]);
+            ->create();
 
         $expectedStatus = "🔴 A new stream just started: $stream->title\nhttps://www.youtube.com/watch?v=$stream->youtube_id";
 
         // Act
-        Artisan::call(TweetAboutLiveStreamsCommand::class);
+        $this->artisan(TweetAboutLiveStreamsCommand::class);
 
         // Assert
         $this->twitterFake->assertLastTweetMessageWas($expectedStatus);
@@ -82,15 +82,15 @@ class TweetAboutLiveStreamsCommandTest extends TestCase
     public function it_correctly_sets_tweeted_at_timestamp(): void
     {
         // Arrange
-        $streamToTweet = Stream::factory()->create(['status' => StreamData::STATUS_LIVE]);
-        $streamDontTweet = Stream::factory()->create(['status' => StreamData::STATUS_UPCOMING]);
+        $streamToTweet = Stream::factory()->live()->create();
+        $streamDontTweet = Stream::factory()->upcoming()->create();
 
         // Assert
         $this->assertFalse($streamToTweet->hasBeenTweeted());
         $this->assertFalse($streamDontTweet->hasBeenTweeted());
 
         // Act
-        Artisan::call(TweetAboutLiveStreamsCommand::class);
+        $this->artisan(TweetAboutLiveStreamsCommand::class);
 
         // Assert
         $this->assertTrue($streamToTweet->refresh()->hasBeenTweeted());
@@ -101,10 +101,10 @@ class TweetAboutLiveStreamsCommandTest extends TestCase
     public function it_only_tweets_streams_that_are_going_live_once(): void
     {
         // Arrange
-        Stream::factory()->create(['status' => StreamData::STATUS_LIVE, 'tweeted_at' => now()]);
+        Stream::factory()->live()->create(['tweeted_at' => now()]);
 
         // Act
-        Artisan::call(TweetAboutLiveStreamsCommand::class);
+        $this->artisan(TweetAboutLiveStreamsCommand::class);
 
         // Assert
         $this->twitterFake->assertNoTweetsWereSent();

--- a/tests/Feature/ImportYoutubeChannelStreamsTest.php
+++ b/tests/Feature/ImportYoutubeChannelStreamsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Jobs\ImportYoutubeChannelStreamsJob;
+use App\Models\Channel;
 use App\Models\Stream;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
@@ -47,6 +48,8 @@ class ImportYoutubeChannelStreamsTest extends TestCase
             '*video*' => Http::response($this->videoResponse()),
         ]);
 
+        $channel = Channel::factory()->create(['platform_id' => 'UCNlUCA4VORBx8X-h-rXvXEg']);
+
         // Assert
         $this->assertDatabaseCount(Stream::class, 0);
 
@@ -56,7 +59,7 @@ class ImportYoutubeChannelStreamsTest extends TestCase
         // Assert
         $this->assertDatabaseCount(Stream::class, 3);
         $this->assertDatabaseHas(Stream::class, [
-            'channel_id' => 'UCNlUCA4VORBx8X-h-rXvXEg',
+            'channel_id' => $channel->id,
         ]);
 
         $stream = Stream::first();


### PR DESCRIPTION
When importing the streams for the channel you want to add the **Model Channel id** to the Stream; not the **ChannelId** from **Youtube** because of the relationship with your own channels. This way the tweets will include the twitter handle if set. 

Another way to fix this is changing the relation on the Stream model to: 
```php
public function channel(): BelongsTo
{
    return $this->belongsTo(Channel::class, 'channel_id', 'platform_id');
}
````

We might also want to change the database column type on the streams table to match the channel_id on the channels table.