### PR TITLE
Fix - Delete streams where the video is not given anymore

### DIFF
--- a/app/Console/Commands/UpdateUpcomingStreamsCommand.php
+++ b/app/Console/Commands/UpdateUpcomingStreamsCommand.php
@@ -32,7 +32,7 @@ class UpdateUpcomingStreamsCommand extends Command
 
         $youtubeResponse = Youtube::videos($streams->keys());
 
-        $streams->map(function (Stream $stream) use ($youtubeResponse) {
+        $streams->each(function (Stream $stream) use ($youtubeResponse) {
 
             /** @var StreamData|null $streamData */
             $streamData = $youtubeResponse->where('videoId', $stream->youtube_id)->first();

--- a/app/Console/Commands/UpdateUpcomingStreamsCommand.php
+++ b/app/Console/Commands/UpdateUpcomingStreamsCommand.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Facades\Youtube;
 use App\Models\Stream;
 use App\Services\Youtube\StreamData;
+use Carbon\Carbon;
 use Illuminate\Console\Command;
 
 class UpdateUpcomingStreamsCommand extends Command
@@ -29,21 +30,33 @@ class UpdateUpcomingStreamsCommand extends Command
 
         $this->info("Fetching {$streams->count()} stream(s) from API to update.");
 
-        $updatesCount = Youtube::videos($streams->keys())
-            ->map(fn(StreamData $streamData) => optional($streams
-                ->get($streamData->videoId))
-                ->update([
-                    'title' => $streamData->title,
-                    'description' => $streamData->description,
-                    'channel_title' => $streamData->channelTitle,
-                    'thumbnail_url' => $streamData->thumbnailUrl,
-                    'scheduled_start_time' => $streamData->plannedStart,
-                    'status' => $streamData->status,
-                ]))
-            ->filter()
-            ->count();
+        $youtubeResponse = Youtube::videos($streams->keys());
 
-        $this->info($updatesCount.' stream(s) were updated.');
+        $streams->map(function (Stream $stream) use ($youtubeResponse) {
+
+            /** @var StreamData|null $streamData */
+            $streamData = $youtubeResponse->where('videoId', $stream->youtube_id)->first();
+
+            if (is_null($streamData)) {
+                $stream->update([
+                    'status' => StreamData::STATUS_DELETED,
+                    'hidden_at' => Carbon::now(),
+                ]);
+
+                return;
+            }
+
+            $stream->update([
+                'title' => $streamData->title,
+                'description' => $streamData->description,
+                'channel_title' => $streamData->channelTitle,
+                'thumbnail_url' => $streamData->thumbnailUrl,
+                'scheduled_start_time' => $streamData->plannedStart,
+                'status' => $streamData->status,
+            ]);
+        });
+
+        $this->info($streams->count() . ' stream(s) were updated.');
 
         return self::SUCCESS;
     }


### PR DESCRIPTION
This PR fixes #79.

I think this task should be in the `UpdateUpcomingStreamsCommand` because this is responsible for checking upcoming streams. I adapted the command (similar to the `UpdateLiveAndFinishedStreamsCommand`) so that we can handle streams where there is no response from Youtube anymore.

Can you take a look @spaantje?