### PR TITLE
Add language filter to ics file

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -6,7 +6,6 @@ use App\Models\Stream;
 use Carbon\CarbonInterval;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Support\Arr;
 use Spatie\IcalendarGenerator\Components\Calendar;
 
 class CalendarController extends Controller
@@ -22,7 +21,7 @@ class CalendarController extends Controller
         Stream::query()
             ->when(
                 $request->get('languages'),
-                fn($query, $languages) => $query->whereIn('language_code', Arr::wrap(explode(',', $languages)))
+                fn($query, $languages) => $query->whereIn('language_code', explode(',', $languages))
             )
             ->notOlderThanAYear()
             ->each(fn(Stream $stream) => $calendar->event(

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -6,6 +6,7 @@ use App\Models\Stream;
 use Carbon\CarbonInterval;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Arr;
 use Spatie\IcalendarGenerator\Components\Calendar;
 
 class CalendarController extends Controller
@@ -19,6 +20,10 @@ class CalendarController extends Controller
             ->productIdentifier('larastreamers.com');
 
         Stream::query()
+            ->when(
+                $request->get('languages'),
+                fn($query, $languages) => $query->whereIn('language_code', Arr::wrap(explode(',', $languages)))
+            )
             ->notOlderThanAYear()
             ->each(fn(Stream $stream) => $calendar->event(
                 $stream->toCalendarItem()

--- a/tests/Feature/Http/Controllers/CalendarControllerTest.php
+++ b/tests/Feature/Http/Controllers/CalendarControllerTest.php
@@ -76,6 +76,30 @@ class CalendarControllerTest extends TestCase
     }
 
     /** @test */
+    public function it_can_filter_streams_by_single_language_code()
+    {
+        Stream::factory()->create(['title' => 'English Test Stream', 'language_code' => 'en']);
+        Stream::factory()->create(['title' => 'Spanish Test Stream', 'language_code' => 'es']);
+
+        $this->get(route('calendar.ics', ['languages' => 'en']))
+            ->assertSee('English Test Stream')
+            ->assertDontSee('Spanish Test Stream');
+    }
+
+    /** @test */
+    public function it_can_filter_streams_by_multiple_language_codes()
+    {
+        Stream::factory()->create(['title' => 'English Test Stream', 'language_code' => 'en']);
+        Stream::factory()->create(['title' => 'Spanish Test Stream', 'language_code' => 'es']);
+        Stream::factory()->create(['title' => 'French Test Stream', 'language_code' => 'fr']);
+
+        $this->get(route('calendar.ics', ['languages' => 'en,es']))
+            ->assertSee('English Test Stream')
+            ->assertSee('Spanish Test Stream')
+            ->assertDontSee('French Test Stream');
+    }
+
+    /** @test */
     public function it_can_download_one_calendar_item(): void
     {
         $stream = Stream::factory()->create([


### PR DESCRIPTION
The current implementation of the ics file adds all streams to the calendar. This is great but there are streams in languages I don't understand, which I really don't need.

The way I implemented this, you specify the languages you want to add to the calendar comma separated:
```
https://larastreamers.com/calendar.ics?languages=en,es
```

I am not sure how we should bring this to the UI, maybe this can be part of the redesign.