### PR TITLE
Fix and test for shortened youtube urls

### DIFF
--- a/app/Http/Livewire/SubmitYouTubeLiveStream.php
+++ b/app/Http/Livewire/SubmitYouTubeLiveStream.php
@@ -54,10 +54,11 @@ class SubmitYouTubeLiveStream extends Component
     private function determineYoutubeId(): ?string
     {
         if (filter_var($this->youTubeIdOrUrl, FILTER_VALIDATE_URL)) {
-            $query = parse_url($this->youTubeIdOrUrl, PHP_URL_QUERY);
-            parse_str($query, $result);
-
-            return $result['v'];
+            if($query = parse_url($this->youTubeIdOrUrl, PHP_URL_QUERY)) {
+                parse_str($query, $result);
+                return $result['v'];
+            }
+            return substr($this->youTubeIdOrUrl, strrpos($this->youTubeIdOrUrl, '/') + 1);
         }
 
         return $this->youTubeIdOrUrl;

--- a/tests/Feature/Http/Livewire/SubmitYouTubeLiveStreamTest.php
+++ b/tests/Feature/Http/Livewire/SubmitYouTubeLiveStreamTest.php
@@ -55,6 +55,26 @@ class SubmitYouTubeLiveStreamTest extends TestCase
     }
 
     /** @test */
+    public function it_calls_the_submit_action_with_short_youtube_url(): void
+    {
+        // Arrange
+        $shortYoutubeUrl = 'https://youtu.be/1234';
+        $this->mock(SubmitStreamAction::class)
+            ->shouldReceive('handle')
+            ->withArgs(['1234', 'de', 'test@test.at'])
+            ->once();
+
+        $this->mockYouTubVideoCall();
+
+        // Arrange & Act & Assert
+        Livewire::test(SubmitYouTubeLiveStream::class)
+            ->set('youTubeIdOrUrl', $shortYoutubeUrl)
+            ->set('submittedByEmail', 'test@test.at')
+            ->set('languageCode', 'de')
+            ->call('submit');
+    }
+
+    /** @test */
     public function it_shows_a_success_message(): void
     {
         // Arrange


### PR DESCRIPTION
I've added in a fix for issue #89 which checks if there are no URL parameters, it grabs the ID from the URL instead. It might be more verbose though to check if the URL is a youtu.be URL first maybe?

I've also added in a test to cover this.