### PR TITLE
Use plural helper for stream(s) count on streamers page

### DIFF
--- a/resources/views/components/streamer-channel.blade.php
+++ b/resources/views/components/streamer-channel.blade.php
@@ -14,8 +14,7 @@
         </div>
         <div class="flex justify-between">
             <a class="px-3 py-2 text-sm font-medium text-white transition bg-red rounded-md shadow hover:bg-red-dark focus:bg-red focus:outline-none"
-               href="{{ route('archive', ['streamer' => $channel->hashid]) }}">Show {{ $channel->approved_finished_streams_count }}
-                streams</a>
+               href="{{ route('archive', ['streamer' => $channel->hashid]) }}">Show {{ $channel->approved_finished_streams_count }} {{ \Illuminate\Support\Str::plural('stream', $channel->approved_finished_streams_count) }}</a>
             <div>
                 <a href="{{ $channel->url() }}">
                     <x-icons.youtube

--- a/tests/Feature/PageStreamersTest.php
+++ b/tests/Feature/PageStreamersTest.php
@@ -99,7 +99,7 @@ class PageStreamersTest extends TestCase
             ->for(Channel::factory())
             ->approved()
             ->finished()
-            ->count(20)
+            ->count(1)
             ->create();
         Stream::factory()
             ->for(Channel::factory())
@@ -112,10 +112,10 @@ class PageStreamersTest extends TestCase
         $response = $this->get(route('streamers'));
 
         // Assert
-        $response->assertSeeInOrder([
-            'Show 30',
-            'Show 20',
-            'Show 10',
+        $response->assertSeeText([
+            'Show 30 streams',
+            'Show 10 streams',
+            'Show 1 stream',
         ]);
     }
 


### PR DESCRIPTION
This PR fixes the buttons on the streamers page to show plural and singular name