### PR TITLE
Fix/a11y with time tag for streams

### DIFF
--- a/app/Models/Stream.php
+++ b/app/Models/Stream.php
@@ -281,4 +281,9 @@ class Stream extends Model implements Feedable
 
         return "Starts {$this->scheduled_start_time->diffForHumans()}";
     }
+
+    public function getStartForRobotsAttribute(): string
+    {
+        return $this->actual_start_time->toIso8601String() ?? $this->scheduled_start_time->toIso8601String();
+    }
 }

--- a/app/Models/Stream.php
+++ b/app/Models/Stream.php
@@ -284,6 +284,6 @@ class Stream extends Model implements Feedable
 
     public function getStartForRobotsAttribute(): string
     {
-        return $this->actual_start_time->toIso8601String() ?? $this->scheduled_start_time->toIso8601String();
+        return $this->actual_start_time?->toIso8601String() ?? $this->scheduled_start_time?->toIso8601String();
     }
 }

--- a/resources/views/components/local-time.blade.php
+++ b/resources/views/components/local-time.blade.php
@@ -1,4 +1,5 @@
-<span
+<time
+    datetime="{{ $date->toIso8601String() }}"
     x-data="{
         formatLocalTimeZone: function (element, timestamp) {
             const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -12,4 +13,4 @@
     {{ $attributes }}
 >
     {{ $date->format('Y-m-d H:i') }}
-</span>
+</time>

--- a/resources/views/pages/partials/header/preview.blade.php
+++ b/resources/views/pages/partials/header/preview.blade.php
@@ -1,15 +1,15 @@
 @if($upcomingStream)
-    <div class="hidden md:block relative w-2/5">
+    <div class="relative hidden w-2/5 md:block">
         <a href="{{ $upcomingStream->url() }}">
 
             <div
-                class="z-10 absolute -top-4 left-8 bg-red rounded-xl font-bold text-xs text-white uppercase tracking-widest p-2">
+                class="absolute z-10 p-2 text-xs font-bold tracking-widest text-white uppercase -top-4 left-8 bg-red rounded-xl">
                 @if($upcomingStream->isLive())  Live @else Upcoming @endif
             </div>
-            <div class="rounded-xl overflow-hidden shadow-lg">
+            <div class="overflow-hidden shadow-lg rounded-xl">
 
 
-                <div class="bg-white flex flex-col">
+                <div class="flex flex-col bg-white">
                     <figure class="overflow-auto aspect-w-16 aspect-h-9">
                         <img class="object-cover w-full h-full"
                              src="{{ $upcomingStream->thumbnail_url }}"
@@ -17,14 +17,14 @@
                     </figure>
 
                     <div class="p-8">
-                        <h3 class="mb-4 font-bold text-xl">{{ $upcomingStream->title }}</h3>
-                        <p class="mb-2 text-base text-gray-dark flex items-center">
-                            <x-icons.icon-user class="w-4 h-4 mr-2 inline text-gray-dark fill-current stroke-current"/>
+                        <h3 class="mb-4 text-xl font-bold">{{ $upcomingStream->title }}</h3>
+                        <p class="flex items-center mb-2 text-base text-gray-dark">
+                            <x-icons.icon-user class="inline w-4 h-4 mr-2 fill-current stroke-current text-gray-dark"/>
                             {{ $upcomingStream->channel->name }}  @if ($upcomingStream->language?->shouldRender())
                                 ({{ $upcomingStream->language->name }}) @endif
-                        <p class="text-base text-gray-dark flex items-center">
-                            <x-icons.icon-time class="w-4 h-4 mr-2 inline text-gray-dark fill-current stroke-current"/>
-                            <time class="text-base text-gray-dark flex">
+                        <p class="flex items-center text-base text-gray-dark">
+                            <x-icons.icon-time class="inline w-4 h-4 mr-2 fill-current stroke-current text-gray-dark"/>
+                            <time datetime="{{ $upcomingStream->actual_start_time }}" class="flex text-base text-gray-dark">
                                {{ $upcomingStream->startForHumans }}
                             </time>
                         </p>

--- a/resources/views/pages/partials/header/preview.blade.php
+++ b/resources/views/pages/partials/header/preview.blade.php
@@ -24,7 +24,7 @@
                                 ({{ $upcomingStream->language->name }}) @endif
                         <p class="flex items-center text-base text-gray-dark">
                             <x-icons.icon-time class="inline w-4 h-4 mr-2 fill-current stroke-current text-gray-dark"/>
-                            <time datetime="{{ $upcomingStream->actual_start_time }}" class="flex text-base text-gray-dark">
+                            <time datetime="{{ $upcomingStream->startForRobots }}" class="flex text-base text-gray-dark">
                                {{ $upcomingStream->startForHumans }}
                             </time>
                         </p>


### PR DESCRIPTION
Following [yesterday's stream](https://www.youtube.com/watch?v=Xr0r2Ft_ROQ)
Let's provide a readable string (ISO8601, thus it includes the timezone) to the datetime attribute of the time tag.

- Added this to the preview card on top of the homepage
- Added to the local-time element, adjusted from `span` to `time` tag

Note:
- Seems like my vscode has re-sorted the tailwind classes, not sure if that's a problem.
- Some tests seem to fail, unrelated to this change. Also, not entirely sure if you want actual tests for these?
- I'm getting new versions of livewire files in public/ - push along?