### PR TITLE
Do not reference models and platform code in migrations

### DIFF
--- a/database/migrations/2021_10_23_073416_update_stream_status_none_to_finished.php
+++ b/database/migrations/2021_10_23_073416_update_stream_status_none_to_finished.php
@@ -1,13 +1,16 @@
 <?php
 
-use App\Models\Stream;
-use App\Services\YouTube\StreamData;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 class UpdateStreamStatusNoneToFinished extends Migration
 {
-    public function up()
+    public function up(): void
     {
-        Stream::where('status', 'none')->update(['status' => StreamData::STATUS_FINISHED]);
+        DB::table('streams')
+            ->where('status', 'none')
+            ->update([
+                'status' => 'finished',
+            ]);
     }
 }


### PR DESCRIPTION
Referencing the model itself or other platform code in migrations is dangerous as should the model be renamed or even remoed the migration would no longer work or should a constant change the migration might behave different than was intended. This PR updates the migrations to use the `DB` `QueryBuilder` instead of the `Eloquent` one to avoid these Problems.
