### PR TITLE
Use Http macro to avoid calling configuration in class v2

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,27 +2,27 @@
 
 namespace App\Providers;
 
+use App\Services\YouTube\YouTubeException;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
-    /**
-     * Register any application services.
-     *
-     * @return void
-     */
-    public function register()
+    public function boot(): void
     {
-        //
-    }
-
-    /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        //
+        Http::macro('youtube', function(string $url, array $params = [], string $key = null): Collection {
+            /** @var Factory $this */
+            return $this
+                ->asJson()
+                ->baseUrl('https://youtube.googleapis.com/youtube/v3/')
+                ->get($url, array_merge($params, [
+                    'key' => config('services.youtube.key'),
+                ]))
+                ->onError(fn(Response $response) => throw YouTubeException::general($response->status(), $response->body()))
+                ->collect($key);
+        });
     }
 }

--- a/app/Services/YouTubeClient.php
+++ b/app/Services/YouTubeClient.php
@@ -6,7 +6,6 @@ use App\Services\YouTube\ChannelData;
 use App\Services\YouTube\StreamData;
 use App\Services\YouTube\YouTubeException;
 use Carbon\Carbon;
-use Illuminate\Http\Client\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 
@@ -21,36 +20,29 @@ class YouTubeClient
 
     public function channels(iterable|string $channelIds): Collection
     {
-        return collect($this->fetch('channels', [
-            'id' => is_string($channelIds) ? $channelIds : collect($channelIds)->implode(','),
+        return Http::youtube('channels', [
+            'id' => collect($channelIds)->implode(','),
             'part' => 'snippet',
-        ], 'items'))
-            ->map(fn(array $item) => new ChannelData(
-                platformId: data_get($item, 'id'),
-                youTubeCustomUrl: data_get($item, 'snippet.customUrl', ''),
-                name: data_get($item, 'snippet.title'),
-                description: data_get($item, 'snippet.description', ''),
-                onPlatformSince: $this->toCarbon(data_get($item, 'snippet.publishedAt')),
-                thumbnailUrl: last(data_get($item, 'snippet.thumbnails'))['url'] ?? null,
-                country: data_get($item, 'snippet.country', ''),
-            ));
+        ], 'items')->map(fn(array $item) => new ChannelData(
+            platformId: data_get($item, 'id'),
+            youTubeCustomUrl: data_get($item, 'snippet.customUrl', ''),
+            name: data_get($item, 'snippet.title'),
+            description: data_get($item, 'snippet.description', ''),
+            onPlatformSince: $this->toCarbon(data_get($item, 'snippet.publishedAt')),
+            thumbnailUrl: last(data_get($item, 'snippet.thumbnails'))['url'] ?? null,
+            country: data_get($item, 'snippet.country', ''),
+        ));
     }
 
     public function upcomingStreams(string $channelId): Collection
     {
-        $videoIds = $this->fetch('search', [
+        return Http::youtube('search', [
             'channelId' => $channelId,
             'eventType' => 'upcoming',
             'type' => 'video',
             'part' => 'id',
             'maxResults' => 25,
-        ], 'items.*.id.videoId');
-
-        if (empty($videoIds)) {
-            return collect();
-        }
-
-        return $this->videos($videoIds);
+        ], 'items.*.id.videoId')->whenNotEmpty(fn(Collection $videoIds) => $this->videos($videoIds));
     }
 
     public function video(string $id): StreamData
@@ -62,10 +54,10 @@ class YouTubeClient
 
     public function videos(iterable|string $videoIds): Collection
     {
-        return collect($this->fetch('videos', [
-            'id' => is_string($videoIds) ? $videoIds : collect($videoIds)->implode(','),
+        return Http::youtube('videos', [
+            'id' => collect($videoIds)->implode(','),
             'part' => 'snippet,statistics,liveStreamingDetails',
-        ], 'items'))
+        ], 'items')
             ->map(fn(array $youTubeVideoDetails) => new StreamData(
                 videoId: data_get($youTubeVideoDetails, 'id'),
                 title: data_get($youTubeVideoDetails, 'snippet.title'),
@@ -85,17 +77,6 @@ class YouTubeClient
     {
         return $this->toCarbon(data_get($data, 'liveStreamingDetails.scheduledStartTime', now()))
             ?? $this->toCarbon(data_get($data, 'snippet.publishedAt', now()));
-    }
-
-    protected function fetch(string $url, array $params = [], string $key = null): array
-    {
-        return Http::asJson()
-            ->baseUrl('https://youtube.googleapis.com/youtube/v3/')
-            ->get($url, array_merge($params, [
-                'key' => config('services.youtube.key'),
-            ]))
-            ->onError(fn(Response $response) => throw YouTubeException::general($response->status(), $response->body()))
-            ->json($key, []);
     }
 
     protected function toCarbon(?string $string): ?Carbon


### PR DESCRIPTION
Hey @christophrumpel, as the title implies this is v2 of the implementation, looking at the code I think I found the issue. I forgot actually merging the parameters with the key when calling `array_merge`. I compared the generated urls with each other and they're now identical so I think this should work now.

https://github.com/christophrumpel/larastreamers/blob/f9dda0c697b2e3f020f26d5db62d3b2c52f4c5a7/app/Providers/AppServiceProvider.php#L21-L23
