### PR TITLE
show stream description

### DIFF
--- a/resources/views/pages/partials/stream.blade.php
+++ b/resources/views/pages/partials/stream.blade.php
@@ -58,7 +58,6 @@
                 </li>
             </ul>
             @endif
-
         </header>
 
         <ul class="w-full sm:w-auto flex flex-wrap gap-3 md:gap-6">

--- a/resources/views/pages/partials/stream.blade.php
+++ b/resources/views/pages/partials/stream.blade.php
@@ -27,7 +27,9 @@
                 </a>
             </h3>
 
+            @if ($stream->description)
             <p class="my-2">{{ $stream->description }}</p>
+            @endif
 
             <ul class="w-full sm:w-auto flex flex-wrap gap-3 md:gap-6 my-2">
                 <li class="w-full sm:w-auto group">

--- a/resources/views/pages/partials/stream.blade.php
+++ b/resources/views/pages/partials/stream.blade.php
@@ -27,23 +27,36 @@
                 </a>
             </h3>
 
-            <p class="text-base text-gray-light flex items-center">
-                <x-icons.icon-user class="w-4 h-4 mr-2 inline text-gray fill-current stroke-current"/>
-                {{ $stream->channel->name }}
-            </p>
+            <p class="my-2">{{ $stream->description }}</p>
 
-            <p class="text-base text-gray-light flex items-center">
-                <x-icons.icon-time class="w-4 h-4 mr-2 inline text-gray fill-current stroke-current"/>
-                <x-local-time class=""
-                              :date="$date = $stream->actual_start_time ?? $stream->scheduled_start_time"
-                              :format="$date->isToday() ? 'HH:mm (z)' : 'YYYY-MM-DD HH:mm (z)'"/>
-            </p>
+            <ul class="w-full sm:w-auto flex flex-wrap gap-3 md:gap-6 my-2">
+                <li class="w-full sm:w-auto group">
+                    <p class="text-sm text-gray-light flex items-center">
+                        <x-icons.icon-user class="w-4 h-4 mr-2 inline text-gray fill-current stroke-current"/>
+                        {{ $stream->channel->name }}
+                    </p>
+                </li>
+                <li class="w-full sm:w-auto group">
+                    <p class="text-sm text-gray-light flex items-center">
+                        <x-icons.icon-time class="w-4 h-4 mr-2 inline text-gray fill-current stroke-current"/>
+                        <x-local-time class=""
+                                      :date="$date = $stream->actual_start_time ?? $stream->scheduled_start_time"
+                                      :format="$date->isToday() ? 'HH:mm (z)' : 'YYYY-MM-DD HH:mm (z)'"/>
+                    </p>
+                </li>
+            </ul>
+
             @if ($stream->language->shouldRender())
-                <p class="text-base text-gray-light flex items-center">
-                    <x-icons.world class="w-4 h-4 mr-2 inline text-gray fill-current stroke-current"/>
-                    <span class="">{{ $stream->language->name }}</span>
-                </p>
+            <ul class="w-full sm:w-auto flex flex-wrap gap-3 md:gap-6 my-2">
+                <li class="w-full sm:w-auto group">
+                    <p class="text-sm text-gray-light flex items-center">
+                        <x-icons.world class="w-4 h-4 mr-2 inline text-gray fill-current stroke-current"/>
+                        <span class="">{{ $stream->language->name }}</span>
+                    </p>
+                </li>
+            </ul>
             @endif
+
         </header>
 
         <ul class="w-full sm:w-auto flex flex-wrap gap-3 md:gap-6">


### PR DESCRIPTION
I figured it would be useful to show the description of a Stream in the feed on the homepage as it's currently not immediately clear what a Stream is about, without visiting it on Youtube. 

This PR changes feed items to look like:

![image](https://user-images.githubusercontent.com/7534029/147935715-56361c7a-0a28-4d7d-b28b-07dd8fe6a5ba.png)

I've also moved the channel name and time onto one line and decreased the size of the text. We don't want these boxes to look _too_ big. If a Stream has a language that is renderable, that will show on a separate line 