### PR TITLE
prevent streamers with no finished streams from showing

### DIFF
--- a/app/Http/Livewire/StreamListArchive.php
+++ b/app/Http/Livewire/StreamListArchive.php
@@ -39,7 +39,7 @@ class StreamListArchive extends Component
             ->paginate(24);
 
         // @phpstan-ignore-next-line
-        $channels = Channel::select(['id', 'name'])->get()->pluck('name', 'hashid');
+        $channels = Channel::has('approvedFinishedStreams')->select(['id', 'name'])->get()->pluck('name', 'hashid');
 
         return view('livewire.stream-list-archive', [
             'streams' => $streams,

--- a/tests/Feature/Http/Livewire/StreamListArchiveTest.php
+++ b/tests/Feature/Http/Livewire/StreamListArchiveTest.php
@@ -27,15 +27,13 @@ it('only shows streams by selected streamer', function() {
 
 it('shows streamers as dropdown options', function() {
     // Arrange
-    $channel_a = Channel::factory()
-        ->create(['name' => 'Channel A']);
-    $channel_b = Channel::factory()
-        ->create(['name' => 'Channel B']);
+    Stream::factory()
+        ->for(Channel::factory()->create(['name' => 'Channel A']))
+        ->create(['status' => StreamData::STATUS_FINISHED]);
 
     Stream::factory()
-        ->create(['channel_id' => $channel_a->id, 'status' => StreamData::STATUS_FINISHED]);
-    Stream::factory()
-        ->create(['channel_id' => $channel_b->id, 'status' => StreamData::STATUS_FINISHED]);
+        ->for(Channel::factory()->create(['name' => 'Channel B']))
+        ->create(['status' => StreamData::STATUS_FINISHED]);
 
     // Arrange & Act & Assert
     Livewire::test(StreamListArchive::class)

--- a/tests/Feature/Http/Livewire/StreamListArchiveTest.php
+++ b/tests/Feature/Http/Livewire/StreamListArchiveTest.php
@@ -5,6 +5,7 @@ use App\Models\Channel;
 use App\Models\Stream;
 use Livewire\Livewire;
 use Vinkla\Hashids\Facades\Hashids;
+use App\Services\YouTube\StreamData;
 
 it('only shows streams by selected streamer', function() {
     // Arrange
@@ -26,10 +27,15 @@ it('only shows streams by selected streamer', function() {
 
 it('shows streamers as dropdown options', function() {
     // Arrange
-    Channel::factory()
+    $channel_a = Channel::factory()
         ->create(['name' => 'Channel A']);
-    Channel::factory()
+    $channel_b = Channel::factory()
         ->create(['name' => 'Channel B']);
+
+    Stream::factory()
+        ->create(['channel_id' => $channel_a->id, 'status' => StreamData::STATUS_FINISHED]);
+    Stream::factory()
+        ->create(['channel_id' => $channel_b->id, 'status' => StreamData::STATUS_FINISHED]);
 
     // Arrange & Act & Assert
     Livewire::test(StreamListArchive::class)
@@ -43,4 +49,14 @@ it('wires properties and methods', function() {
     // Arrange & Act & Assert
     Livewire::test(StreamListArchive::class)
         ->assertPropertyWired('streamer');
+});
+
+it('does not show streamer as dropdown option without approved finished streams', function () {
+    // Arrange
+    Channel::factory()
+        ->create(['name' => 'Channel A']);
+
+    // Arrange & Act & Assert
+    Livewire::test(StreamListArchive::class)
+        ->assertDontSee('Channel A');
 });

--- a/tests/Feature/PageArchiveTest.php
+++ b/tests/Feature/PageArchiveTest.php
@@ -139,10 +139,18 @@ it('searches for streams by specific streamer and search term', function() {
 
 it('orders streamers by name', function() {
     // Arrange
-    Channel::factory()->create(['name' => 'Laravel']);
-    Channel::factory()->create(['name' => 'Christoph Rumpel']);
-    Channel::factory()->create(['name' => 'Adrian Nürnberger']);
-    Channel::factory()->create(['name' => 'Caleb Porzio']);
+    Channel::factory()
+        ->has(Stream::factory()->finished())
+        ->create(['name' => 'Laravel']);
+    Channel::factory()
+        ->has(Stream::factory()->finished())
+        ->create(['name' => 'Christoph Rumpel']);
+    Channel::factory()
+        ->has(Stream::factory()->finished())
+        ->create(['name' => 'Adrian Nürnberger']);
+    Channel::factory()
+        ->has(Stream::factory()->finished())
+        ->create(['name' => 'Caleb Porzio']);
 
     // Act & Assert
     $this->get(route('archive'))


### PR DESCRIPTION
Fixes #158 

Streamers were showing as filterable on the Archive page despite having no finished streams, so when you filtered the archive by them, nothing showed up. 