### PR TITLE
use channel name in feed

### DIFF
--- a/app/Models/Stream.php
+++ b/app/Models/Stream.php
@@ -200,7 +200,7 @@ class Stream extends Model implements Feedable
             ->summary((string) $this->description)
             ->updated($this->updated_at ?? now())
             ->link($this->url())
-            ->authorName($this->title);
+            ->authorName($this->channel->name);
     }
 
     public function url(): string

--- a/app/Models/Stream.php
+++ b/app/Models/Stream.php
@@ -194,13 +194,15 @@ class Stream extends Model implements Feedable
 
     public function toFeedItem(): FeedItem
     {
+        $channel = Channel::find($this->channel_id);
+
         return FeedItem::create()
             ->id((string) $this->id)
             ->title($this->title)
             ->summary((string) $this->description)
             ->updated($this->updated_at ?? now())
             ->link($this->url())
-            ->authorName($this->channel->name);
+            ->authorName($channel ? $channel->name : '');
     }
 
     public function url(): string

--- a/app/Models/Stream.php
+++ b/app/Models/Stream.php
@@ -194,15 +194,13 @@ class Stream extends Model implements Feedable
 
     public function toFeedItem(): FeedItem
     {
-        $channel = Channel::find($this->channel_id);
-
         return FeedItem::create()
             ->id((string) $this->id)
             ->title($this->title)
             ->summary((string) $this->description)
             ->updated($this->updated_at ?? now())
             ->link($this->url())
-            ->authorName($channel ? $channel->name : '');
+            ->authorName($this->channel()->first(['id', 'name'])?->name ?? '');
     }
 
     public function url(): string


### PR DESCRIPTION
The feed was setting the stream name as the author name, so you'd get this:

```xml
<author>
    <name>
        <![CDATA[ Laravel Livewire: How Does It Work? 🧐 ]]>
    </name>
</author>
```

But that's already specified in the `<title></title>` tags. This PR changes it to use the name of the related channel, so you get:

```xml
<author>
    <name>
        <![CDATA[ Christoph Rumpel ]]>
    </name>
</author>
```

This issue was mentioned in the discussion [here](https://github.com/christophrumpel/larastreamers/discussions/127#discussioncomment-1772453). 