### PR TITLE
Fix border radius on select

### DIFF
--- a/resources/views/components/search.blade.php
+++ b/resources/views/components/search.blade.php
@@ -4,7 +4,7 @@
         <label for="streamer" class="sr-only">Filter by streamer</label>
         <select wire:model="streamer"
                 id="streamer"
-            class="border-white focus:border-1 focus:border-red"
+            class="border-white focus:border-1 focus:border-red rounded-l-lg"
         >
             <option value="">All Streamers</option>
             @foreach($channels as $hashId => $channel)


### PR DESCRIPTION
I noticed that the border style is slightly wrong on the focused select field.

Before:
<img width="324" alt="CleanShot 2022-01-11 at 16 42 38@2x" src="https://user-images.githubusercontent.com/24483576/148974444-671b6115-7945-4652-ae31-59042964ab29.png">

After:
<img width="182" alt="CleanShot 2022-01-11 at 16 42 45@2x" src="https://user-images.githubusercontent.com/24483576/148974458-ebc294bf-b38f-4a30-907e-d932aac9f073.png">

