### PR TITLE
Order streamer list by name

### DIFF
--- a/app/Http/Livewire/StreamListArchive.php
+++ b/app/Http/Livewire/StreamListArchive.php
@@ -39,7 +39,7 @@ class StreamListArchive extends Component
             ->paginate(24);
 
         // @phpstan-ignore-next-line
-        $channels = Channel::select(['id', 'name'])->get()->pluck('name', 'hashid');
+        $channels = Channel::select(['id', 'name'])->orderBy('name')->get()->pluck('name', 'hashid');
 
         return view('livewire.stream-list-archive', [
             'streams' => $streams,

--- a/tests/Feature/PageArchiveTest.php
+++ b/tests/Feature/PageArchiveTest.php
@@ -136,3 +136,20 @@ it('searches for streams by specific streamer and search term', function() {
         ->assertSee('Stream Shown')
         ->assertDontSee('Stream Hidden');
 });
+
+it('orders streamers by name', function () {
+    // Arrange
+    Channel::factory()->create(['name' => 'Laravel']);
+    Channel::factory()->create(['name' => 'Christoph Rumpel']);
+    Channel::factory()->create(['name' => 'Adrian Nürnberger']);
+    Channel::factory()->create(['name' => 'Caleb Porzio']);
+
+    // Act & Assert
+    $this->get(route('archive'))
+        ->assertSeeInOrder([
+            'Adrian Nürnberger',
+            'Caleb Porzio',
+            'Christoph Rumpel',
+            'Laravel',
+        ]);
+});


### PR DESCRIPTION
On the archive page, streamers are currently sorted by id. This PR changes the order by name which in my opinion is way easier.

Before:
<img width="228" alt="CleanShot 2022-01-11 at 16 49 10@2x" src="https://user-images.githubusercontent.com/24483576/148975654-84e0a64e-b245-4dd2-a7bc-20c722026e9d.png">

After:
<img width="221" alt="CleanShot 2022-01-11 at 16 49 23@2x" src="https://user-images.githubusercontent.com/24483576/148975686-089102f7-791d-43ea-b212-fa6f7f07dac6.png">

