### PR TITLE
update summary tweet pluralisation

### DIFF
--- a/app/Console/Commands/TweetAboutWeeklySummaryCommand.php
+++ b/app/Console/Commands/TweetAboutWeeklySummaryCommand.php
@@ -30,7 +30,7 @@ class TweetAboutWeeklySummaryCommand extends Command
             $streamsCount == 1 ? 'was' : 'were',
             $streamsCount,
             Str::plural('stream', $streamsCount),
-        $streamsCount == 1 ? 'Thanks to everyone who participated.' : 'Thanks to all the streamers and viewers.'
+            $streamsCount == 1 ? 'Thanks to everyone who participated.' : 'Thanks to all the streamers and viewers.'
         ));
 
         return self::SUCCESS;

--- a/app/Console/Commands/TweetAboutWeeklySummaryCommand.php
+++ b/app/Console/Commands/TweetAboutWeeklySummaryCommand.php
@@ -26,7 +26,12 @@ class TweetAboutWeeklySummaryCommand extends Command
             return self::SUCCESS;
         }
 
-        Twitter::tweet($streamsCount.Str::plural(' stream', $streamsCount)." happened last week. 👏 Thanks to all the streamers and viewers. 🙏🏻\n Find them here: ".route('archive'));
+        Twitter::tweet(sprintf("Last week, there %s %s %s. 👏 %s 🙏🏻\n Find more Streams here: ".route('archive'),
+            $streamsCount == 1 ? 'was' : 'were',
+            $streamsCount,
+            Str::plural('stream', $streamsCount),
+        $streamsCount == 1 ? 'Thanks to everyone who participated.' : 'Thanks to all the streamers and viewers.'
+        ));
 
         return self::SUCCESS;
     }

--- a/app/Console/Commands/TweetAboutWeeklySummaryCommand.php
+++ b/app/Console/Commands/TweetAboutWeeklySummaryCommand.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Facades\Twitter;
 use App\Models\Stream;
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 
 class TweetAboutWeeklySummaryCommand extends Command
 {
@@ -25,7 +26,7 @@ class TweetAboutWeeklySummaryCommand extends Command
             return self::SUCCESS;
         }
 
-        Twitter::tweet("There were $streamsCount streams last week. 👏 Thanks to all the streamers and viewers. 🙏🏻\n Find them here: ".route('archive'));
+        Twitter::tweet($streamsCount.Str::plural(' stream', $streamsCount)." happened last week. 👏 Thanks to all the streamers and viewers. 🙏🏻\n Find them here: ".route('archive'));
 
         return self::SUCCESS;
     }

--- a/tests/Feature/Commands/TweetAboutWeeklySummaryCommandTest.php
+++ b/tests/Feature/Commands/TweetAboutWeeklySummaryCommandTest.php
@@ -29,7 +29,7 @@ it('tweets weekly summary', function() {
 
     // Assert
     Twitter::assertTweetCount(1)
-        ->assertLastTweet("There were 2 streams last week. 👏 Thanks to all the streamers and viewers. 🙏🏻\n Find them here: ".route('archive'));
+        ->assertLastTweet("2 streams happened last week. 👏 Thanks to all the streamers and viewers. 🙏🏻\n Find them here: ".route('archive'));
 });
 
 it('does not tweet weekly summary when no streams given', function() {

--- a/tests/Feature/Commands/TweetAboutWeeklySummaryCommandTest.php
+++ b/tests/Feature/Commands/TweetAboutWeeklySummaryCommandTest.php
@@ -9,7 +9,24 @@ beforeEach(function() {
     Twitter::fake();
 });
 
-it('tweets weekly summary', function() {
+it('tweets weekly summary for a single stream', function() {
+    // Arrange
+    $startOfLastWeek = Carbon::today()->subWeek()->startOfWeek();
+
+    Stream::factory()
+        ->approved()
+        ->finished()
+        ->create(['actual_start_time' => $startOfLastWeek]);
+
+    // Act
+    $this->artisan(TweetAboutWeeklySummaryCommand::class);
+
+    // Assert
+    Twitter::assertTweetCount(1)
+        ->assertLastTweet("Last week, there was 1 stream. 👏 Thanks to everyone who participated. 🙏🏻\n Find more Streams here: ".route('archive'));
+});
+
+it('tweets weekly summary for a multiple streams', function() {
     // Arrange
     $startOfLastWeek = Carbon::today()->subWeek()->startOfWeek();
     $endOfLastWeek = Carbon::today()->subWeek()->endOfWeek()->endOfDay();
@@ -29,7 +46,7 @@ it('tweets weekly summary', function() {
 
     // Assert
     Twitter::assertTweetCount(1)
-        ->assertLastTweet("2 streams happened last week. 👏 Thanks to all the streamers and viewers. 🙏🏻\n Find them here: ".route('archive'));
+        ->assertLastTweet("Last week, there were 2 streams. 👏 Thanks to all the streamers and viewers. 🙏🏻\n Find more Streams here: ".route('archive'));
 });
 
 it('does not tweet weekly summary when no streams given', function() {


### PR DESCRIPTION
This is a small update to the Tweet that sends out as a summary. Previously, if only 1 Stream was found, the following would be Tweeted:

> There were 1 streams last week. 👏 Thanks to all the streamers and viewers. 🙏🏻

There's no account for pluralisation, so this PR changes it to be:

> 1 stream happened last week. 👏 Thanks to all the streamers and viewers. 🙏🏻

and then if it's more than one:

> 2 streams happened last week. 👏 Thanks to all the streamers and viewers. 🙏🏻
> 3 streams happened last week. 👏 Thanks to all the streamers and viewers. 🙏🏻

etc, etc

Fixes #175 