### PR TITLE
Fix alignment

### DIFF
--- a/resources/views/components/streamer-channel.blade.php
+++ b/resources/views/components/streamer-channel.blade.php
@@ -3,8 +3,8 @@
         <img class="-mt-12 w-full rounded-md overflow-hidden shadow" src="{{ $channel->thumbnail_url }}"
              alt="YouTube channel image from {{ $channel->name }}"/>
     </div>
-    <div class="flex flex-col w-4/5 pl-8">
-        <div class="mb-6">
+    <div class="flex flex-col w-4/5 pl-8 h-full">
+        <div class="mb-6 flex-1">
             <p class="font-bold text-white mb-2">{{ $channel->name }}</p>
             @if($channel->country)
                 <div class="flex items-center text-gray mb-4">


### PR DESCRIPTION
This PR updates the link section of the streamer channel card to always be positioned at the very bottom of the card. I think this way it looks way cleaner.

Before
<img width="1248" alt="CleanShot 2022-01-27 at 12 45 54@2x" src="https://user-images.githubusercontent.com/24483576/151352985-7f9ba671-8146-4918-97db-1957f4aa0c51.png">

After
<img width="1225" alt="CleanShot 2022-01-27 at 12 46 08@2x" src="https://user-images.githubusercontent.com/24483576/151353002-7fac9a07-8dc8-493f-85ab-937161dc982b.png">

