### PR TITLE
Reset page when streamer property is updated

### DIFF
--- a/app/Http/Livewire/StreamListArchive.php
+++ b/app/Http/Livewire/StreamListArchive.php
@@ -27,6 +27,11 @@ class StreamListArchive extends Component
         $this->resetPage();
     }
 
+    public function updatedStreamer(): void
+    {
+        $this->resetPage();
+    }
+
     public function render(): View
     {
         $streams = Stream::query()

--- a/tests/Feature/Http/Livewire/StreamListArchiveTest.php
+++ b/tests/Feature/Http/Livewire/StreamListArchiveTest.php
@@ -58,3 +58,19 @@ it('does not show streamer as dropdown option without approved finished streams'
     Livewire::test(StreamListArchive::class)
         ->assertDontSee('Channel A');
 });
+
+it('resets the pagination when selecting a streamer from the dropdown', function() {
+    // Arrange
+    Stream::factory()
+        ->for($channel = Channel::factory()->create())
+        ->finished()
+        ->create(['title' => 'Stream Seen']);
+
+    // Act & Assert
+    Livewire::withQueryParams(['page' => 2])
+        ->test(StreamListArchive::class)
+        ->assertDontSee('Stream Seen')
+        ->set('streamer', $channel->hash)
+        ->assertSet('page', 1)
+        ->assertSee('Stream Seen');
+});


### PR DESCRIPTION
This PR fixes #165 by resetting the page when the streamer property is updated just like it was already done with the search property.

I tried to add a test but I messing around with the page property on the class directly doesn't behave like expected. Maybe there is something I am missing.