### PR TITLE
add stream count to archive page

### DIFF
--- a/app/Http/Livewire/StreamListArchive.php
+++ b/app/Http/Livewire/StreamListArchive.php
@@ -44,7 +44,7 @@ class StreamListArchive extends Component
             ->paginate(24);
 
         // @phpstan-ignore-next-line
-        $channels = Channel::has('approvedFinishedStreams')->orderBy('name')->select('id', 'name')->withCount('approvedFinishedStreams')->get()->keyBy('hashId');
+        $channels = Channel::has('approvedFinishedStreams')->select('id', 'name')->orderBy('name')->withCount('approvedFinishedStreams')->get()->keyBy('hashId');
 
         return view('livewire.stream-list-archive', [
             'streams' => $streams,

--- a/app/Http/Livewire/StreamListArchive.php
+++ b/app/Http/Livewire/StreamListArchive.php
@@ -43,7 +43,6 @@ class StreamListArchive extends Component
             ->fromLatestToOldest()
             ->paginate(24);
 
-        // @phpstan-ignore-next-line
         $channels = Channel::has('approvedFinishedStreams')->select('id', 'name')->orderBy('name')->withCount('approvedFinishedStreams')->get()->keyBy('hashId');
 
         return view('livewire.stream-list-archive', [

--- a/app/Http/Livewire/StreamListArchive.php
+++ b/app/Http/Livewire/StreamListArchive.php
@@ -44,7 +44,7 @@ class StreamListArchive extends Component
             ->paginate(24);
 
         // @phpstan-ignore-next-line
-        $channels = Channel::has('approvedFinishedStreams')->select(['id', 'name'])->orderBy('name')->get()->pluck('name', 'hashid');
+        $channels = Channel::has('approvedFinishedStreams')->orderBy('name')->select('id', 'name')->withCount('approvedFinishedStreams')->get()->keyBy('hashId');
 
         return view('livewire.stream-list-archive', [
             'streams' => $streams,

--- a/resources/views/components/search.blade.php
+++ b/resources/views/components/search.blade.php
@@ -7,7 +7,7 @@
         >
             <option value="">All Streamers</option>
             @foreach($channels as $hashId => $channel)
-                <option value="{{ $hashId }}" wire:key="streamer_{{ $hashId }}">{{ $channel }}</option>
+                <option value="{{ $hashId }}" wire:key="streamer_{{ $hashId }}">{{ $channel->name }} ({{ $channel->approved_finished_streams_count }})</option>
             @endforeach
         </select>
 

--- a/resources/views/livewire/stream-list-archive.blade.php
+++ b/resources/views/livewire/stream-list-archive.blade.php
@@ -1,5 +1,5 @@
 <div>
-    <x-page-header title="Archive ({{ $streams->count() }})">
+    <x-page-header title="Archive ({{ $streams->total() }})">
         <x-search wire:model.debounce.300ms="search" :channels="$channels" />
     </x-page-header>
 

--- a/resources/views/livewire/stream-list-archive.blade.php
+++ b/resources/views/livewire/stream-list-archive.blade.php
@@ -1,5 +1,5 @@
 <div>
-    <x-page-header title="Archive">
+    <x-page-header title="Archive ({{ $streams->count() }})">
         <x-search wire:model.debounce.300ms="search" :channels="$channels" />
     </x-page-header>
 

--- a/resources/views/pages/streamers.blade.php
+++ b/resources/views/pages/streamers.blade.php
@@ -1,6 +1,6 @@
 <x-main-layout title="Larastreamers Streamers" description="The Hall Of Fame Of Larastreamers 🔥">
 
-    <x-page-header title="Streamers" />
+    <x-page-header title="Streamers ({{ $channels->count() }})" />
 
     <main class="flex-1 text-white bg-gray-darkest">
         <div class="w-full max-w-6xl mx-auto px-6 xl:px-0 py-24 space-y-16">

--- a/tests/Feature/Http/Livewire/StreamListArchiveTest.php
+++ b/tests/Feature/Http/Livewire/StreamListArchiveTest.php
@@ -38,8 +38,8 @@ it('shows streamers as dropdown options', function() {
     // Arrange & Act & Assert
     Livewire::test(StreamListArchive::class)
         ->assertSee([
-            'Channel A',
-            'Channel B',
+            'Channel A (1)',
+            'Channel B (1)',
         ]);
 });
 


### PR DESCRIPTION
Fixes https://github.com/christophrumpel/larastreamers/issues/249

Adds a count into the header of the Archive page:

![image](https://user-images.githubusercontent.com/7534029/184560927-58ffce64-6a62-4b15-9f0d-5c1f4dfac3c8.png)

Along with a count for each Streamer in the search dropdown:

![image](https://user-images.githubusercontent.com/7534029/184560964-332e2740-22d0-406e-859e-2f05f984fd72.png)

I've also added a count to the main Streamers page too, just for consistency and I think it would be nice to watch that number grow:

![image](https://user-images.githubusercontent.com/7534029/184561001-2b56e5ae-456b-4505-90db-d7e8491c1219.png)
